### PR TITLE
fix for celery not working in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ COPY /arches_her/docker/entrypoint.sh ${WEB_ROOT}/entrypoint.sh
 RUN chmod -R 700 ${WEB_ROOT}/entrypoint.sh &&\
   dos2unix ${WEB_ROOT}/entrypoint.sh
 
+RUN pip install supervisor
+
 RUN mkdir /var/log/supervisor
 RUN mkdir /var/log/celery
 

--- a/docker/conf.d/aher-celerybeat.conf
+++ b/docker/conf.d/aher-celerybeat.conf
@@ -3,7 +3,7 @@
 ; ================================
 
 [program:celerybeat]
-	command=/usr/local/bin/celery beat -A ss.celery --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid
+	command=/root/.local/bin/celery beat -A arches_her --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid
 	directory=/web_root/arches_her
 
     user=root

--- a/docker/conf.d/aher-celeryd.conf
+++ b/docker/conf.d/aher-celeryd.conf
@@ -3,7 +3,7 @@
 ; ==================================
 
 [program:celery]
-    command=/usr/local/bin/celery worker -A ssc.celery --loglevel=INFO
+    command=/root/.local/bin/celery worker -A arches_her --loglevel=INFO
     directory=/web_root/arches_her
 
     user=root


### PR DESCRIPTION
installs supervisor and correctly configured celery and celerybeat files.

requires image rebuild to pick up changes.