### PR TITLE
Autopopulate function - string template reset before config save

### DIFF
--- a/arches_her/media/js/views/components/functions/autopopulate-node-from-card-nodes-function.js
+++ b/arches_her/media/js/views/components/functions/autopopulate-node-from-card-nodes-function.js
@@ -168,7 +168,10 @@ function (ko, koMapping, FunctionViewModel, chosen, AlertViewModel) {
 
 
             this.trigger_string_template_reset = function(){
+                var target_node = ko.unwrap(self.target_node)
+                self.target_node(undefined);
                 self.reset_string_template(true);
+                self.target_node(target_node);
             }
 
 


### PR DESCRIPTION
There was a slight functionality issue where if the configuration hadn't been saved, the string template reset button would not result in a reset of the template.

The computed function that generates the string template appears to be dependent upon a change in the target_node observable prior to a save of the configuration.  The code changes on lines 171 - 174 temporarily sets the target_node observable to undefined before reapplying the value.

@aj-he - This may not be the most elegant way of going about this but it's the only way I could get it to behave as I needed it to.