### PR TITLE
fix keystone plugin routes AB#40316

### DIFF
--- a/arches_her/media/js/views/components/plugins/active-consultations.js
+++ b/arches_her/media/js/views/components/plugins/active-consultations.js
@@ -12,7 +12,7 @@ define([
     return ko.components.register('active-consultations',  {
         viewModel: function(params) {
             var self = this;
-            this.resourceEditorURL = '/arches-her' + arches.urls.resource_editor;
+            this.resourceEditorURL = arches.urls.resource_editor;
             this.moment = moment;
             this.layout = ko.observable('grid');
             this.setLayout = function(layout){ self.layout(layout); };

--- a/arches_her/media/js/views/components/plugins/init-workflow.js
+++ b/arches_her/media/js/views/components/plugins/init-workflow.js
@@ -5,7 +5,7 @@ define([
 
     var InitWorkflow = function(params) {
         this.workflows = params.workflows.map(function(wf){
-            wf.url = "/arches-her" + arches.urls.plugin(wf.slug);
+            wf.url = "/keystone" + arches.urls.plugin(wf.slug);
             return wf;
         }, this);
     };


### PR DESCRIPTION
updated hard coded reference arches-her.

- Active consultations now uses the default resource editor.
- plugins now uses "keystone".