### PR TITLE
Makes None a valid value for bng datatype

### DIFF
--- a/arches_her/datatypes/bngcentrepoint.py
+++ b/arches_her/datatypes/bngcentrepoint.py
@@ -24,6 +24,9 @@ class BNGCentreDataType(BaseDataType):
     def validate(self, value, row_number=None, source=None, node=None, nodeid=None, strict=False):
 
         errors = []
+        if value is None:
+            return errors
+        
         gridSquareArray = [
             "NA",
             "NB",


### PR DESCRIPTION
Make it so that it only validates if the value is not None in the event of an empty tile being created using `Tile.get_blank_tile`