### PR TITLE
Archive Holding as Array

### DIFF
--- a/arches_her/media/js/views/components/reports/archive-source.js
+++ b/arches_her/media/js/views/components/reports/archive-source.js
@@ -92,7 +92,11 @@ define([
                 }
             }
 
-            const archiveHoldingNode = self.getRawNodeValue(self.resource(), 'archive holding');
+            let archiveHoldingNode = self.getRawNodeValue(self.resource(), 'archive holding');
+
+            if(archiveHoldingNode && !Array.isArray(archiveHoldingNode)){
+                archiveHoldingNode = [archiveHoldingNode];
+            }
 
             if(Array.isArray(archiveHoldingNode) && self.cards?.['archive holding']) {
                 self.archiveHolding(archiveHoldingNode.map(node => {

--- a/arches_her/templates/views/components/reports/archive-source.htm
+++ b/arches_her/templates/views/components/reports/archive-source.htm
@@ -71,7 +71,6 @@
                     <!-- ko foreach: { data: archiveHolding, as: "archive", noChildContext: true} -->
                     <!-- ko if: !!archive && archive.data -->
                     <div class="aher-report-subsection">
-                        <h2 class="aher-report-section-subtitle"><i data-bind="click: function() {toggleVisibility(archive.visible)}, css: {'fa-angle-double-right': archive.visible(), 'fa-angle-double-up': !archive.visible()}" class="fa toggle"></i> <span>{% trans "Holding" %}</span></h2>
                         <div data-bind="visible: archive.visible">
                             <!-- ko foreach: { data: archive.data.section, as: "section", noChildContext: true} -->
                             <div class="aher-report-subsection">

--- a/arches_her/templates/views/components/reports/archive-source.htm
+++ b/arches_her/templates/views/components/reports/archive-source.htm
@@ -14,7 +14,7 @@
     </div>
     {% endblock report_title_bar %}
 
-    
+
     {% block body %}
     <!-- Link nav -->
     <div class="aher-report-anchor-container">
@@ -71,7 +71,7 @@
                     <!-- ko foreach: { data: archiveHolding, as: "archive", noChildContext: true} -->
                     <!-- ko if: !!archive && archive.data -->
                     <div class="aher-report-subsection">
-                        <h2 class="aher-report-section-subtitle"><i data-bind="click: function() {toggleVisibility(archive.visible)}, css: {'fa-angle-double-right': archive.visible(), 'fa-angle-double-up': !archive.visible()}" class="fa toggle"></i> <span>{% trans "Holding" %}</span> <span data-bind="text: $index() + 1"></span></h2>
+                        <h2 class="aher-report-section-subtitle"><i data-bind="click: function() {toggleVisibility(archive.visible)}, css: {'fa-angle-double-right': archive.visible(), 'fa-angle-double-up': !archive.visible()}" class="fa toggle"></i> <span>{% trans "Holding" %}</span></h2>
                         <div data-bind="visible: archive.visible">
                             <!-- ko foreach: { data: archive.data.section, as: "section", noChildContext: true} -->
                             <div class="aher-report-subsection">
@@ -79,7 +79,7 @@
                                 <a data-bind="{if: section.card, click: function(){addNewTile(section.card)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Edit" %} <span data-bind="text:section.title"></span></a>
 
                                 <div data-bind="visible: section.visible" class="aher-report-collapsible-container">
-                                    
+
                                     <div class="aher-report-event-section aher-report-subsection-container">
                                         <div style="width:95%" data-bind="foreach: {data: section.data, as: 'item'}" class="aher-report-subsection-two-column">
                                             <div class="aher-keyvalue" data-bind="component: {
@@ -133,7 +133,7 @@
                 }"></div>
             </div>
         </div>
-    </div>            
+    </div>
     {% endblock body %}
 {% endblock report %}
 


### PR DESCRIPTION
By switching Archive Holding from a multiple instance to single instance card, the logic behind the report section for Archive Holding failed to work.

If a value is returned for Archive Holding, it is forcing into being an array.

Index value has been removed for Holding subheading in the template as, in Keystone, this should only have one value.