### PR TITLE
Handles empty self.cards

### DIFF
--- a/arches_her/media/js/views/components/reports/archive-source.js
+++ b/arches_her/media/js/views/components/reports/archive-source.js
@@ -98,11 +98,11 @@ define([
                 archiveHoldingNode = [archiveHoldingNode];
             }
 
-            if(Array.isArray(archiveHoldingNode) && self.cards?.['archive holding']) {
+            if(Array.isArray(archiveHoldingNode)) {
                 self.archiveHolding(archiveHoldingNode.map(node => {
                     const tileid = self.getTileId(node);
-                    const archiveHoldingTile = self.cards?.['archive holding'].tiles().find(tile => tile.tileid === tileid);
-                    const archiveHoldingCards = self.createCardDictionary(archiveHoldingTile.cards);
+                    const archiveHoldingTile = self.cards?.['archive holding']?.tiles().find(tile => tile.tileid === tileid);
+                    const archiveHoldingCards = archiveHoldingTile ? self.createCardDictionary(archiveHoldingTile.cards) : null;
                     return {
                         tileid,
                         visible: ko.observable(true),


### PR DESCRIPTION
Further change to the Archive Sources report JS file to display data correctly in the report view as well as the resource report view