### PR TITLE
48854 correspondence workflow server 500 error when contact name for correspondence value is missing from person resource #AB48854

### DIFF
--- a/arches_her/views/file_template.py
+++ b/arches_her/views/file_template.py
@@ -363,9 +363,10 @@ class FileTemplateView(View):
                 associate_heritage
             )
 
+        htmlTags = re.compile(r"<(?:\"[^\"]*\"['\"]*|'[^']*'['\"]*|[^'\">])+>")
         for key in mapping_dict:
             html = False
-            if "<" in mapping_dict[key]:  # look for html tag, not ideal
+            if htmlTags.search(mapping_dict[key] if mapping_dict[key] is not None else ""):
                 html = True
             self.replace_string(self.doc, key, mapping_dict[key], html)
 


### PR DESCRIPTION
[Bug 48854](https://hedev.visualstudio.com/Inventory/_workitems/edit/48854): KEY: Correspondence workflow server 500 error when contact name for correspondence value is missing from Person resource