### PR TITLE
resourceinstanceid is None when deleting resource. Put TRY block around SQL execution #AB48848

### DIFF
--- a/arches_her/pkg/extensions/functions/he-primary-descriptors/he_primary_descriptors.py
+++ b/arches_her/pkg/extensions/functions/he-primary-descriptors/he_primary_descriptors.py
@@ -60,11 +60,14 @@ class HEPrimaryDescriptors(AbstractPrimaryDescriptorsFunction):
                 select objects.value
                 from tile_value, jsonb_each(tiledata) objects
                 where objects.key::text = nodeid::text"""
-            with connection.cursor() as cursor:
-                cursor.execute(sql)
-                row = cursor.fetchone()
-                if row and row[0] is not None:
-                    primary_reference_number = str(row[0])
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(sql)
+                    row = cursor.fetchone()
+                    if row and row[0] is not None:
+                        primary_reference_number = str(row[0])
+            except:
+                pass
         try:
             if "nodegroup_id" in config and config["nodegroup_id"] != "" and config["nodegroup_id"] is not None:
                 tiles = models.TileModel.objects.filter(nodegroup_id=uuid.UUID(config["nodegroup_id"]), sortorder=0).filter(


### PR DESCRIPTION
[Bug 48848](https://hedev.visualstudio.com/Inventory/_workitems/edit/48848): KEY: Request failed message when deleting a resource

Descriptor functions get called at the drop of a hat, and in the cases the value of resource.resourceinstanceid is None, which when you're injecting in to a query expecting a UUID - the query execution errors. Sufficient to wrap query execution in TRY block.