### PR TITLE
Table header row containing "Actions" getting doubled up

### DIFF
--- a/arches_her/media/js/views/components/reports/application-area.js
+++ b/arches_her/media/js/views/components/reports/application-area.js
@@ -28,7 +28,6 @@ define([
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(2).fill(null)
             };
 

--- a/arches_her/media/js/views/components/reports/scenes/people.js
+++ b/arches_her/media/js/views/components/reports/scenes/people.js
@@ -9,7 +9,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(7).fill(null)
             };
 

--- a/arches_her/media/js/views/components/reports/scenes/resources.js
+++ b/arches_her/media/js/views/components/reports/scenes/resources.js
@@ -9,7 +9,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(2).fill(null)
             };
 
@@ -19,7 +18,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(4).fill(null)
             };
 
@@ -29,7 +27,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(3).fill(null)
             };
 


### PR DESCRIPTION
scrollY was causing datatables' last column header to get duplicated i.e. the 'Actions' table header was repeated where table configs specified a scrollY value.