### PR TITLE
45813 - Consultation Status Date Trigger (Attempt 2) AB#45813

### DIFF
--- a/arches_her/functions/consultation_status_function.py
+++ b/arches_her/functions/consultation_status_function.py
@@ -1,9 +1,12 @@
+from operator import truediv
 import uuid
 import json
+import datetime
 from arches.app.functions.base import BaseFunction
 from arches.app.models import models
 from arches.app.models.tile import Tile
 from arches.app.datatypes.datatypes import DataTypeFactory
+import logging
 
 
 details = {
@@ -11,120 +14,117 @@ details = {
     'type': 'node',
     'description': 'Triggers change in status node of consultation instance',
     'defaultconfig': {
-        "cons_status_list_nodegroupid":"8d41e4c0-a250-11e9-a7e3-00224800b26d",
-        "cons_status_list_nodeid":"8d41e4d3-a250-11e9-8977-00224800b26d"
+        "cons_comp_date_nodeid":"40eff4ce-893a-11ea-ae2e-f875a44e0e11",
+        "cons_status_bool_nodeid":"6a773228-db20-11e9-b6dd-784f435179ea",
         },
     'classname': 'ConsultationStatusFunction',
     'component': '',
     'functionid':'96efa95a-1e2c-4562-ac1f-b415796f9f75'
 }
 
-class ConsultationStatusFunction(BaseFunction): 
+class ConsultationStatusFunction(BaseFunction):
+
+    def handle_boolean_tile(self,tile,nodegroupid,nodeid,status):
+        try:
+            nodeid_str = str(nodeid)
+            cons_status_tile = None
+
+            cons_status_tile_filter = Tile.objects.filter(nodegroup_id=nodegroupid, resourceinstance_id=tile.resourceinstance_id)
+            if len(cons_status_tile_filter) > 0:
+                cons_status_tile = cons_status_tile_filter[0]
+            else:
+                cons_status_tile = Tile().get_blank_tile_from_nodegroup_id(resourceid = tile.resourceinstance_id,nodegroup_id = nodegroupid)
+
+            if cons_status_tile != None:
+
+                cons_status_tile_data = cons_status_tile.data
+                cons_status_tile_data[nodeid_str] = status
+                try:
+                    cons_status_tile.save()
+                    return True
+
+                except Exception as e:
+                    self.logger.error(e, "Could not create boolean tile")
+                    return False
+
+            else:
+                return False
+
+        except Exception as e:
+                self.logger.error(e, "Could not create boolean tile")
+                return False
+
+
+    def save_cons_tile(self, tile, request, is_function_save_method=True):
+
+        if request is None and is_function_save_method == True:
+            return
+
+        cons_status_bool_nodeid = self.config["cons_status_bool_nodeid"]
+        cons_status_bool_filter = Tile.objects.filter(resourceinstance_id=tile.resourceinstance_id,nodegroup_id=cons_status_bool_nodeid)
+        date_comp_node = models.Node.objects.get(nodeid=self.config["cons_comp_date_nodeid"])
+        if len(cons_status_bool_filter) > 0:
+            date_comp_tile = None
+            if tile.nodegroup_id == str(date_comp_node.nodegroup_id):
+                    date_comp_tile = tile
+            else:
+                date_comp_tile_filter = Tile.objects.filter(resourceinstance_id=tile.resourceinstance_id,nodegroup_id=date_comp_node.nodegroup_id)
+                if len(date_comp_tile_filter) > 0:
+                    date_comp_tile = date_comp_tile_filter[0]
+            if  date_comp_tile != None:
+                datatype_factory = DataTypeFactory()
+                datatype = datatype_factory.get_instance(date_comp_node.datatype)
+                date_comp_value = datatype.get_display_value(tile,date_comp_node)
+                if date_comp_value != None:
+                    try:
+                        self.handle_boolean_tile(tile,cons_status_bool_nodeid,cons_status_bool_nodeid,False)
+                        return
+                    except Exception as e:
+                        self.logger.error(e,"Could not compare today's date and completed date")
+                        return
+                else:
+                    return
+        else:
+            self.handle_boolean_tile(tile,cons_status_bool_nodeid,cons_status_bool_nodeid,True)
+            return
+
+        return
+
 
     def save(self, tile, request, context=None):
-        cons_status_list_nodeid = "8d41e4d3-a250-11e9-8977-00224800b26d"
-        cons_status_bool_nodeid = "6a773228-db20-11e9-b6dd-784f435179ea"
+        self.logger = logging.getLogger(__name__)
+        try:
+            self.save_cons_tile(tile=tile, request=request, is_function_save_method=True)
+            return
+        except Exception as e:
+            self.logger.error(e, "Could not save tile")
 
-        active_statuses = [
-            "Mitigation",
-            "Post-excavation assessment",
-            "Pre-decision assessment/evaluation",
-            "Project Initiation",
-            "Dormant",
-            "Publication & archiving"
-        ]
-        if tile.data is not None:
-            if cons_status_list_nodeid in list(tile.data.keys()):
-                datatype_factory = DataTypeFactory()
-                cons_status_list_node = models.Node.objects.get(nodeid=cons_status_list_nodeid)
-                datatype = datatype_factory.get_instance(cons_status_list_node.datatype)
-                tile_status = datatype.get_display_value(tile, cons_status_list_node)
 
-                status = True if tile_status in active_statuses else False
-                resourceinstance_id = str(tile.resourceinstance.resourceinstanceid)
-                cons_status_tile, created = Tile.objects.get_or_create(
-                    resourceinstance_id=resourceinstance_id,
-                    nodegroup_id=cons_status_bool_nodeid,
-                    defaults = {'data':{"6a773228-db20-11e9-b6dd-784f435179ea":status}}
-                )
-
-                if created is False:
-                    try:
-                        # cons_status_tile.data = json.dumps({ "6a773228-db20-11e9-b6dd-784f435179ea":status })
-                        cons_status_tile.data = { "6a773228-db20-11e9-b6dd-784f435179ea":status }
-                    except Exception as e:
-                        print('tile.data assignment error: ',e)
-                    try:
-                        cons_status_tile.save(request=request)
-                    except Exception as e:
-                        print('tile.save error: ',e)
-
-        return
-
-    
     def delete(self,tile,request):
-        cons_status_list_nodeid = "8d41e4d3-a250-11e9-8977-00224800b26d"
-        cons_status_bool_nodeid = "6a773228-db20-11e9-b6dd-784f435179ea"
-        
-        if tile.data is not None:
-            if cons_status_list_nodeid in list(tile.data.keys()):
-                status = False
+        self.logger = logging.getLogger(__name__)
+        try:
+            date_comp_node = models.Node.objects.get(nodeid=self.config["cons_comp_date_nodeid"])
+            cons_status_bool_nodeid = self.config["cons_status_bool_nodeid"]
+            if tile.nodegroup_id == date_comp_node.nodegroup_id:
+                cons_status_bool_filter = Tile.objects.filter(resourceinstance_id=tile.resourceinstance_id,nodegroup_id=cons_status_bool_nodeid)
+                if len(cons_status_bool_filter) > 0:
+                        self.handle_boolean_tile(tile,cons_status_bool_nodeid,cons_status_bool_nodeid,True)
+                        return
+                else:
+                    return
+            else:
+                return
+        except Exception as e:
+                self.logger.error(e, "Could not delete tile")
 
-                resourceinstance_id = str(tile.resourceinstance.resourceinstanceid)
-                cons_status_tile, created = Tile.objects.get_or_create(
-                    resourceinstance_id=resourceinstance_id,
-                    nodegroup_id=cons_status_bool_nodeid,
-                    defaults = {'data':{"6a773228-db20-11e9-b6dd-784f435179ea":status}}
-                )
 
-                if created is False:
-                    try:
-                        # cons_status_tile.data = json.dumps({ "6a773228-db20-11e9-b6dd-784f435179ea":status })
-                        cons_status_tile.data = { "6a773228-db20-11e9-b6dd-784f435179ea":status }
-                    except Exception as e:
-                        print('tile.data assignment error: ',e)
-                    try:
-                        cons_status_tile.save(request=request)
-                    except Exception as e:
-                        print('tile.save error: ',e)
-
-        return
-
-    
     def on_import(self,tile):
-        print("========= on_import ===========")
-        cons_status_list_nodeid = "8d41e4d3-a250-11e9-8977-00224800b26d"
-        cons_status_bool_nodeid = "6a773228-db20-11e9-b6dd-784f435179ea"
+        raise NotImplementedError
 
-        active_statuses = [
-            "Mitigation",
-            "Post-excavation assessment",
-            "Pre-decision assessment/evaluation",
-            "Project Initiation",
-            "Dormant",
-            "Publication & archiving"
-        ]
-        if tile.data is not None:
-            if cons_status_list_nodeid in list(tile.data.keys()):
-                datatype_factory = DataTypeFactory()
-                cons_status_list_node = models.Node.objects.get(nodeid=cons_status_list_nodeid)
-                datatype = datatype_factory.get_instance(cons_status_list_node.datatype)
-                tile_status = datatype.get_display_value(tile, cons_status_list_node)
 
-                status = True if tile_status in active_statuses else False
-                resourceinstance_id = str(tile.resourceinstance.resourceinstanceid)
-                cons_status_tile, created = Tile.objects.get_or_create(
-                    resourceinstance_id=resourceinstance_id,
-                    nodegroup_id=cons_status_bool_nodeid,
-                    defaults = {'data':{"6a773228-db20-11e9-b6dd-784f435179ea":status}}
-                )
-
-        return
-
-    
     def after_function_save(self,tile,request):
         raise NotImplementedError
-    
-    
+
+
     def get(self):
         raise NotImplementedError


### PR DESCRIPTION
Consultation Status function updated so that a status is created/changed as triggered by the creation of a new Consultation resource or the creation/update of the completion date

[AB#45813](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/45813) in Keystone backlog