### PR TITLE
AB#51047 Mitigation Scope Note fix.

### DIFF
--- a/arches_her/views/file_template.py
+++ b/arches_her/views/file_template.py
@@ -245,7 +245,7 @@ class FileTemplateView(View):
             mitigation = {}
             condition = {}
             if str(tile.nodegroup_id) == action_nodegroup_id:
-                mitigation_scopenote = mitigation_scope_dict.get(tile.data[action_type_node_id], "")                
+                mitigation_scopenote = mitigation_scope_dict.get(get_value_from_tile(tile, action_type_node_id), "")
                 if len(mitigation_scopenote) > 0:
                     mitigation_scopenote = "<br>" + mitigation_scopenote
                 mitigation["content"] = "<p>{}</p><p>{}</p>".format(get_value_from_tile(tile, action_node_id), mitigation_scopenote)


### PR DESCRIPTION
Mitigation Scope Note fix : Handle action_type_node_id not found in action_nodegroup tiledata.

[AB#51047](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/51047)