### PR TITLE
AB#46081 AB#46085 AB#46084 AB#47470 - Add Referenced By scene to Application Area reports

### DIFF
--- a/arches_her/media/js/views/components/reports/application-area.js
+++ b/arches_her/media/js/views/components/reports/application-area.js
@@ -6,6 +6,7 @@ define([
     'utils/resource',
     'utils/report',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json'
 ], function($, _, ko, arches, resourceUtils, reportUtils) {
     return ko.components.register('application-area-report', {
@@ -30,6 +31,8 @@ define([
                 searching: true,
                 columns: Array(2).fill(null)
             };
+
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);

--- a/arches_her/media/js/views/components/reports/scenes/referenced-by.js
+++ b/arches_her/media/js/views/components/reports/scenes/referenced-by.js
@@ -1,0 +1,78 @@
+define([
+    'underscore',
+    'knockout',
+    'arches',
+    'utils/report',
+    'bindings/datatable'
+], function(_, ko, arches, reportUtils) {
+    return ko.components.register('views/components/reports/scenes/referenced-by', {
+        viewModel: function(params) {
+            const self = this;
+            Object.assign(self, reportUtils);
+            self.resourceinstanceid = params.resourceInstanceId;
+            self.graphs_array = params.graphs
+            self.graphs_list = []
+            self.graphs = []
+            self.relations = ko.observableArray();
+            self.visible = {
+                referencedBy: ko.observable(true),
+            }
+
+            // referenced by table configuration
+            self.referencedByTwoColumnTableConfig = {
+                ...self.defaultTableConfig,
+                "paging": true,
+                "searching": true,
+                "scrollY": "250px",
+                "columns": Array(2).fill(null),
+                "bDestroy": true
+            };
+
+            self.getGraphs = function(){
+                return $.ajax({
+                    url: arches.urls.graphs_api,
+                    context: this,
+                }).done(function(graphs_response) {
+                    self.graphs = ko.unwrap(graphs_response)
+                    self.graphs_list = []
+                    for(g in self.graphs_array){
+                        var graph_find_result = self.graphs.find((gr) => gr.name === self.graphs_array[g])
+                        self.graphs_list.push(graph_find_result.graphid)
+                    }
+                    return
+                }).fail(function() {
+                    // error
+               })
+            }
+
+
+            self.getRelatedResources = function(){
+                return $.ajax({
+                    url: arches.urls.related_resources + self.resourceinstanceid,
+                    context: self,
+                })
+                    .done(function(response) {
+                        self.getGraphs().then(function(){
+                            var response_related_resources = response.related_resources.related_resources
+                            self.relations.removeAll()
+                            for(r in response_related_resources){
+                                var response_related_resource = response_related_resources[r]
+                                if(self.graphs_list.includes(response_related_resource["graph_id"] )){
+                                    var graph_name = (self.graphs.find((gr) => gr.graphid === response_related_resource["graph_id"]))["name"]
+                                    self.relations.push({"related_resource_name": response_related_resource["displayname"], "related_resource_link": arches.urls.resource_report + response_related_resource["resourceinstanceid"], "related_resource_type": graph_name})
+                                }
+                            }
+                            return
+                        })
+                    })
+                    .fail(function() {
+                         // error
+                    });
+            };
+
+
+
+        },
+        template: { require: 'text!templates/views/components/reports/scenes/referenced-by.htm' }
+    });
+});

--- a/arches_her/templates/views/components/reports/application-area.htm
+++ b/arches_her/templates/views/components/reports/application-area.htm
@@ -26,6 +26,7 @@
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
+
             <!-- Names Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
                 <div data-bind="component: {
@@ -71,6 +72,18 @@
             </div>
             <!-- Resources Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                        graphs: ['Consultation']
+                    }
+                }"></div>
+
+
+
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -79,6 +92,7 @@
                         dataConfig: resourceDataConfig
                     }
                 }"></div>
+
                 <!-- Application Area section -->
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
@@ -189,6 +203,15 @@
             params: {
                 data: resource,
                 cards: descriptionCards,
+            }
+        }"></div>
+
+        <!-- Referenced By section -->
+        <div data-bind="component: {
+            name: 'views/components/reports/scenes/referenced-by',
+            params: {
+                resourceInstanceId: ko.unwrap(resourceinstanceid),
+                graphs: ['Consultation']
             }
         }"></div>
     </div>

--- a/arches_her/templates/views/components/reports/scenes/referenced-by.htm
+++ b/arches_her/templates/views/components/reports/scenes/referenced-by.htm
@@ -1,0 +1,58 @@
+{% extends "views/report-templates/default.htm" %}
+{% load i18n %}
+{% block report %}
+
+{% block body %}
+
+<h2 class="aher-report-section-title"><i tabindex="0" data-bind="click: function() {toggleVisibility(visible.referencedBy)}, css: {'fa-angle-double-right': visible.referencedBy(), 'fa-angle-double-up': !visible.referencedBy()}"  class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Referenced By section"></i> {% trans "Resource Referenced By" %}</h2>
+<!-- Collapsible content -->
+<div data-bind="visible: visible.referencedBy" class="aher-report-collapsible-container pad-lft">
+
+    <!-- ko ifnot: getRelatedResources() -->
+    <div class="aher-nodata-note">{% trans "No resource referenced by for this resource" %}</div>
+    <!-- /ko -->
+
+    <!-- ko if: getRelatedResources() -->
+    <div class="aher-report-subsection">
+        <div class="firstchild-container">
+            <div class="aher-table">
+                <table id="referenced-by-table" class="table table-striped" cellspacing="0" width="100%">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Related Resource" %}</th>
+                            <th>{% trans "Resource Type" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="dataTablesForEach: { data: relations, dataTableOptions: referencedByTwoColumnTableConfig}">
+                        <tr>
+                            <td>
+                                <!-- ko if: related_resource_link -->
+                                <a data-bind="text: related_resource_name, attr: {href: related_resource_link}" class="aher-table-link"></a>
+                                <!-- /ko -->
+                                <!-- ko ifnot: related_resource_link -->
+                                <span data-bind="text: related_resource_name"></span>
+                                <!-- /ko -->
+                            </td>
+                            <td data-bind="text: related_resource_type"></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <!-- /ko -->
+</div>
+
+
+
+
+
+{% endblock body %}
+{% endblock report %}
+{% block summary %}
+
+<div class="model-summary-report">
+Do not use - yet.
+</div>
+
+{% endblock summary %}


### PR DESCRIPTION
[AB#46081](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/46081)
[AB#46085](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/46085) 
[AB#46084](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/46084) 
[AB#47470](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/47470)

- A new Referenced By scene is added to reports scenes
- The Referenced By scene is applied to the top of the Associated Resources tab within the Application Area report
- Consultations the Application Area is referenced by are listed with a hyperlink to the resource
- Referenced By scene is accessible
- While the scene is configured only to return Consultations the Application Area is referenced by, it is possible to add other types of resources in the configuration
- There is no great difference in rendering speed of the Referenced By resources and pagination is used to limit the number displayed at any one time (a default of 10)
