### PR TITLE
AB#50806 AB#54010 Consultations Message Showing Correctly in Report and Resource

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/resources.js
+++ b/arches_her/media/js/views/components/reports/scenes/resources.js
@@ -50,11 +50,11 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
             self.add = params.addTile || self.addNewTile;
             self.activities = ko.observableArray();
             self.consultations = ko.observableArray();
+            self.consultations_message = ko.observable(null);
             self.files = ko.observableArray();
             self.archive = ko.observableArray();
             self.actors = ko.observableArray();
             self.assets = ko.observableArray();
-            self.assets_rob = ko.observableArray();
             self.translation = ko.observableArray();
             self.applicationArea = ko.observableArray();
             self.period = ko.observableArray();
@@ -92,6 +92,44 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                         const resourceUrl = self.getResourceLink(x);
                         return { consultation, resourceUrl, tileid };
                     }));
+                }
+
+
+                const userCanViewConsultations = () => {
+                    if(params.data()[self.dataConfig.consultations]){
+                        try{
+                            return window.fetch(arches.urls.api_nodes(params.data()[self.dataConfig.consultations]['@node_id']))
+                            .then(function(response){
+                                return $.ajax({
+                                    url: response.url,
+                                    context: this,
+                                }).done(function(node_response) {
+                                    return window.fetch(arches.urls.api_nodegroup(ko.unwrap(node_response)[0]["nodegroup_id"]))
+                                    .then(function(response) {
+                                    if (response.ok && response.status === 200) {
+                                        return true;
+                                    } else {
+                                        return false;
+                                        }
+                                    })
+                                }).fail(function() {
+                                    return false
+                            })})
+                            }
+                        catch{
+                            return false
+                        }
+
+                    }
+                     else {
+                        return false;
+                    }
+                }
+
+                if (!userCanViewConsultations()) {
+                    self.consultations_message('You do not have permission to view this data');
+                } else if (associatedConsultationsNode === undefined || associatedConsultationsNode.length === 0) {
+                    self.consultations_message('No consultations for this resource');
                 }
 
 

--- a/arches_her/templates/views/components/reports/scenes/resources.htm
+++ b/arches_her/templates/views/components/reports/scenes/resources.htm
@@ -140,11 +140,11 @@
     <!-- Collapsible content -->
     <div data-bind="visible: visible.consultations" class="aher-report-collapsible-container pad-lft">
 
-        <!-- ko ifnot: consultations().length -->
-        <div class="aher-nodata-note">No consultations for this resource</div>
+        <!-- ko if: consultations_message() !== null -->
+        <div data-bind="text: consultations_message" class="aher-nodata-note"></div>
         <!-- /ko -->
 
-        <!-- ko if: consultations().length -->
+        <!-- ko if: consultations_message() === null && consultations().length -->
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
@@ -317,7 +317,6 @@
     <!-- ko if: cards.actors -->
     <a href="#" data-bind="click: function(){addNewTile(cards.actors)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Person or Organisation" %}</a>
     <!-- /ko -->
-    
     <!-- Collapsible content -->
     <div data-bind="visible: visible.actors" class="aher-report-collapsible-container pad-lft">
 


### PR DESCRIPTION
[AB#50806](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/50806) 
[AB#54010](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/54010)

I had to rework the userCanViewConsultations function that Rob has added to the viewmodel to provide the correct message to the user.  There are no params.cards data when viewing in report view which is why the incorrect message was showing even when a user had permissions to view the data.

NB aside from my rework there are also some changes from Rob's original work which I've copied and pasted in as I didn't have access to the working branch and didn't want to deal with merge conflicts from the 1.1.1 branch that was available (basically, I'm saying some of this work is Rob's as well as mine)

The function now uses inputs that are available in report and resource views.  Tested locally.

Dev Peer reviewer: @RobOatesHistoricEngland 
Tester: @Rehaan-Arif 
Release Merge Lead: @aj-he 