### PR TITLE
AB#50806 Resourceinstanceid added to reports for other graphs

### DIFF
--- a/arches_her/media/js/views/components/reports/activity.js
+++ b/arches_her/media/js/views/components/reports/activity.js
@@ -66,7 +66,8 @@ define([
                 archive: 'associated archive objects',
                 files: 'digital files',
                 assets: 'associated monuments and areas',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.cards = {};

--- a/arches_her/media/js/views/components/reports/area.js
+++ b/arches_her/media/js/views/components/reports/area.js
@@ -55,7 +55,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.locationDataConfig = {

--- a/arches_her/media/js/views/components/reports/historic-aircraft.js
+++ b/arches_her/media/js/views/components/reports/historic-aircraft.js
@@ -56,7 +56,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/maritime-vessel.js
+++ b/arches_her/media/js/views/components/reports/maritime-vessel.js
@@ -67,7 +67,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/person.js
+++ b/arches_her/media/js/views/components/reports/person.js
@@ -81,7 +81,8 @@ define([
             self.resourceDataConfig = {
                 files: 'digital file(s)',
                 archive: undefined,
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
             self.nameCards = {};
             self.descriptionCards = {};


### PR DESCRIPTION
@aj-he I forgot to include the addition of resourceinstanceid to self.resourceDataConfig in the reports viewmodels for Activity, Aircraft, Maritime, Area and Person.

This has now been amended

[AB#50806](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/50806)