### PR TITLE
AB#58752 - Report Links Navigate to Resource Report

### DIFF
--- a/arches_her/media/js/utils/report.js
+++ b/arches_her/media/js/utils/report.js
@@ -190,7 +190,14 @@ define([
             if(node) {
                 const resourceId = node?.resourceId || node?.instance_details?.[0]?.resourceId;
                 if(resourceId){
-                    return `${arches.urls.resource}/${resourceId}`;
+                    urlPathname = window.location.pathname
+                    if(urlPathname.includes("resource")){
+                        return `${arches.urls.resource}/${resourceId}`;
+                    }
+                    else{
+                        return `${arches.urls.resource_report}${resourceId}`;
+                    }
+                    
                 }
             }
         },        


### PR DESCRIPTION
[AB#58752](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/58752)

The link to a related resource now navigates to a resource editor page if the user is looking at a resource in the editor view, or the resource report page if a user is looking at a resource in the report view.

Permissions are still respected.

Peer reviewer: @khodgkinson-he 
Tester: @gouthamrandhi 
Merge lead: @aj-he 