### PR TITLE
AB#59063 Add missing config item to resourcesDataConfig for Consultations

### DIFF
--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -59,7 +59,8 @@ define([
                 assets: 'related monuments and areas',
                 files: 'file(s)',
                 relatedApplicationArea: 'consultation area',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.nameCards = {};


### PR DESCRIPTION
[AB#59063](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/59063)

The missing resourceintanceid item was stopping Associated Resources from being displayed properly in the Consultations reports.

The addition of this item should remedy the issue.

Peer Review: @khodgkinson-he 
Test: @gouthamrandhi 
Merge Lead: @aj-he 