### PR TITLE
AB#59184 Fix reports not showing associated resources

### DIFF
--- a/arches_her/media/js/views/components/reports/application-area.js
+++ b/arches_her/media/js/views/components/reports/application-area.js
@@ -50,7 +50,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.locationDataConfig = {

--- a/arches_her/media/js/views/components/reports/artefact.js
+++ b/arches_her/media/js/views/components/reports/artefact.js
@@ -81,7 +81,8 @@ define([
                 files: 'digital file(s)',
                 consultations: undefined,
                 archive: undefined,
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/heritage-story.js
+++ b/arches_her/media/js/views/components/reports/heritage-story.js
@@ -45,7 +45,8 @@ define([
                 translation: 'translation',
                 period: 'temporal coverage',
                 archive: undefined,
-                actors: 'associated actors'
+                actors: 'associated actors',
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.locationDataConfig = {

--- a/arches_her/media/js/views/components/reports/heritage-story.js
+++ b/arches_her/media/js/views/components/reports/heritage-story.js
@@ -41,7 +41,7 @@ define([
                 activities: undefined,
                 consultations: undefined,
                 files: undefined,
-                assets: 'associated heritage assets, areas and artefacts',
+                assets: 'associated monuments, areas and artefacts',
                 translation: 'translation',
                 period: 'temporal coverage',
                 archive: undefined,

--- a/arches_her/media/js/views/components/reports/organization.js
+++ b/arches_her/media/js/views/components/reports/organization.js
@@ -58,7 +58,8 @@ define([
                 consultations: undefined,
                 files: undefined,
                 archive: undefined,
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.nameCards = {};


### PR DESCRIPTION
AB#59184

The following reports were not showing any associated resources as resourceinstanceid hadn't been added to the resourceDataConfig object:
- Application area
- Heritage Story
- Artefact
- Organizations

There was also an issue in Heritage Story report which still had a reference to Heritage Assets (now changed to Monuments)

Peer Reviewer: @RobOatesHistoricEngland 
Tester: @gouthamrandhi 
Merge lead: @aj-he 