### PR TITLE
Letters - create unique filename using time as suffix

### DIFF
--- a/arches_her/views/file_template.py
+++ b/arches_her/views/file_template.py
@@ -76,22 +76,26 @@ class FileTemplateView(View):
         self.resource.load_tiles()
 
         template_name = self.get_template_path(template_id)
+        filename, file_extension = os.path.splitext(template_name)
         template_path = os.path.join(settings.APP_ROOT, "docx", template_name)
 
-        if os.path.exists(os.path.join(settings.APP_ROOT, "uploadedfiles", "docx")) is False:
-            os.mkdir(os.path.join(settings.APP_ROOT, "uploadedfiles", "docx"))
+        uploaded_docx_path = os.path.join(settings.APP_ROOT, "uploadedfiles", "docx")
+        if not os.path.exists(uploaded_docx_path):
+            os.mkdir(uploaded_docx_path)
 
         try:
             self.doc = Document(template_path)
-        except:
+        except FileNotFoundError:
             return HttpResponseNotFound("No Template Found")
 
         self.edit_letter(self.resource, datatype_factory)
 
-        date = datetime.today()
-        date = date.strftime("%Y") + "-" + date.strftime("%m") + "-" + date.strftime("%d")
-        new_file_name = date + "_" + template_name
-        new_file_path = os.path.join(settings.APP_ROOT, "uploadedfiles/docx", new_file_name)
+        current_datetime = datetime.today()
+        date = current_datetime.strftime("%Y-%m-%d")
+        time = current_datetime.strftime("%H%M%S%f")
+
+        new_file_name = f"{date}_{filename}_{time}{file_extension}"
+        new_file_path = os.path.join(settings.APP_ROOT, "uploadedfiles", "docx", new_file_name)
 
         new_req = HttpRequest()
         new_req.method = "POST"


### PR DESCRIPTION
Fixes situation where browsers are caching outdated downloaded letter template workflow files because a file is deleted and then recreated and the name is reused.

ensures each file is unique everytime the workflow is used.

**BUG details**

Using Microsoft Edge (had been reported but not replicated yet in Chrome)..

1. Create a letter using the consultation letter workflow.
2. Go to the consultation, download the file and then delete the card containing the file.
3. Create a new letter on the same day, using the workflow and the same letter type but for a different consultation.
4. Go to the second consultation and download it.

**Expected result:**

The letter contains information related to the second consultation.


**Actual results:**

The letter for the first consultation that was deleted has been reserved.

[AB#61249](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/61249)