### PR TITLE
Remove non-xml compatible characters from string AB#66488

### DIFF
--- a/arches_her/views/file_template.py
+++ b/arches_her/views/file_template.py
@@ -230,6 +230,28 @@ class FileTemplateView(View):
             returnvalue = datatype.get_display_value(tile, current_node)
             return "" if returnvalue is None else returnvalue
 
+        def remove_non_xml_compatible_chars(s: str) -> str:
+            """
+            Remove characters that are not compatible with XML.
+            XML 1.0 compatible characters:
+            - U+0009, U+000A, U+000D (whitespace characters)
+            - U+0020 to U+D7FF
+            - U+E000 to U+FFFD
+            XML 1.1 additionally allows:
+            - U+0001 to U+0008, U+000B to U+000C, U+000E to U+001F
+            But for broad compatibility, we'll target XML 1.0 here.
+            :param s: Input string
+            :return: String with non-XML-compatible characters removed
+            """
+            # For XML 1.0, adjust ranges if targeting XML 1.1
+            return "".join(
+                char
+                for char in s
+                if ord(char) in (0x9, 0xA, 0xD)
+                or 0x20 <= ord(char) <= 0xD7FF
+                or 0xE000 <= ord(char) <= 0xFFFD
+            )
+
         # Advice and Conditions.
         advice_nodegroup_id = "8d41e49f-a250-11e9-b6b3-00224800b26d"
         advice_node_id = "c36808b0-952c-11ea-9ff0-f875a44e0e11"
@@ -410,7 +432,9 @@ class FileTemplateView(View):
                 mapping_dict[key] if mapping_dict[key] is not None else ""
             ):
                 is_html = True
-            self.replace_string(self.doc, key, mapping_dict[key], is_html)
+
+            xml_compatible_string = remove_non_xml_compatible_chars(mapping_dict[key])
+            self.replace_string(self.doc, key, xml_compatible_string, is_html)
 
     def replace_string(self, document, key, v, is_html=False):
         # Note that the intent here is to preserve how things are styled in the docx


### PR DESCRIPTION
[AB#66488](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/66488)

Discovered through post-deploy testing that it is possible for non-XML compliant unicode characters to break the generation of letters.  Unicode character \u0016 was present in a consultation's proposal description. Due to Word doc's being XML in nature, the presence of this unicode character resulted in a server 500 error.

This fix strips out all non-XML compliant unicode characters.