### PR TITLE
AB#71888 Add Skip to content functionality on homepage

### DIFF
--- a/arches_her/media/css/branding.css
+++ b/arches_her/media/css/branding.css
@@ -324,6 +324,43 @@
     font-weight: 300;
     overflow-x: hidden;
     min-width: 100vw;
+
+    a {
+		&:focus {
+			outline: 2px solid #EC6625 !important;
+		}
+	}
+
+    #skip-link-holder {
+        a, a:link, a:visited {
+            color: #000;
+            background-color: #fae619;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 10px;
+            text-align: center;
+            outline: none !important;
+            max-height: 38px;
+            display: block;
+            width: 100%;
+            position: fixed;
+            top: -38px;
+            left: 0;
+            z-index: 10001;
+        }
+        a:focus, a:active {
+            text-decoration: underline !important;
+            left: 0;
+            top: 0;
+            z-index: 10000000;
+        }
+    }
+    #skip-target-holder {
+        position: absolute;
+        top: -38px;
+        left: 0;
+    }
+
 }
 
 .landing-page a:focus,

--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -69,6 +69,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 <body id="body" class="landing-page">
 
+    <div id="skip-link-holder"><a id="skip-link" href="#skiptocontent">{% trans "Skip to Content" %}</a></div>
+    
     <header>
         <nav class="navbar">
             <div class="container">
@@ -125,6 +127,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </header>
 
     <main>
+        <p id="skip-target-holder">
+            <a id="skiptocontent" name="skiptocontent" class="skip" tabindex="-1" aria-label="{% trans "Skip to Content" %}">
+                {% trans "Skip to Content" %}
+            </a>
+        </p>
         <div class="container">
             <div class="row featurette1">
                 <div class="featurette1-left-container">


### PR DESCRIPTION
[AB#71888](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/71888)

Add the missing `Skip to content` functionality on the homepage that is not inherited by `base-manager.htm`. Activated by pressing `[TAB]` when the page loads.