### PR TITLE
Make login alert render after page load

### DIFF
--- a/arches_her/templates/login.htm
+++ b/arches_her/templates/login.htm
@@ -49,7 +49,7 @@
 					{% endif %}
 					<button id ="sign-in-button" class="btn btn-primary btn-lg" type="submit">{% trans "Sign in" %}</button>
 				</div>
-				<div style="{% if not auth_failed %}display:none;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert" aria-live="Assertive">
+				<div style="display:none;" id="login-failed-alert" class="alert alert-danger fade in" role="alert" aria-live="assertive">
 					<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans "Close" %}</span></button>
 					<p class="alert-title">{% trans "Login failed" %}</p>
 					<span>{% trans "Invalid username and/or password." %}</span>
@@ -62,5 +62,14 @@
 	</main>
 
 </div>
+
+<script>
+	document.addEventListener("DOMContentLoaded", function() {
+		var authFailed = {{ auth_failed|yesno:"true,false" }};
+		if (authFailed) {
+			document.getElementById("login-failed-alert").style.display = "block";
+		}
+	});
+</script>
 
 {% endblock body %}


### PR DESCRIPTION
Changes the alert box to display once the page has loaded if auth_failed rather being rendered at the server.