### PR TITLE
AB#71898 Chevrons not interpreted as expanded or collapsed

### DIFF
--- a/arches_her/media/js/bindings/reports.js
+++ b/arches_her/media/js/bindings/reports.js
@@ -1,0 +1,30 @@
+define([
+    'jquery',
+    'knockout',
+], function ($, ko) {
+    // apply aria attributes to the element when an observable changes between true and false
+    // e.g. <div data-bind="onReportSectionToggleAria: visible.names, sectionName: '{% trans "Section Name" %}'"></div>
+    ko.bindingHandlers.onReportSectionToggleAria = {
+        update: function (element, valueAccessor, allBindings) {
+            var value = ko.utils.unwrapObservable(valueAccessor());
+            var sectionName = allBindings.get('sectionName') || '';
+            $(element).attr('role', 'button');
+            if (value) { // section is expanded
+                $(element).attr('aria-expanded', 'true');
+                $(element).attr('aria-label', 'Section ' + sectionName + ' expanded');
+                $(element).addClass('fa-angle-double-right');
+                $(element).removeClass('fa-angle-double-up');
+
+
+            } else { // collapsed
+                $(element).attr('aria-expanded', 'false');
+                $(element).attr('aria-label', 'Section ' + sectionName + ' collapsed');
+                $(element).removeClass('fa-angle-double-right');
+                $(element).addClass('fa-angle-double-up');
+            }
+        }
+    };
+
+
+    return;
+});

--- a/arches_her/media/js/bindings/reports.js
+++ b/arches_her/media/js/bindings/reports.js
@@ -8,14 +8,11 @@ define([
         update: function (element, valueAccessor, allBindings) {
             var value = ko.utils.unwrapObservable(valueAccessor());
             var sectionName = allBindings.get('sectionName') || '';
-            $(element).attr('role', 'button');
             if (value) { // section is expanded
                 $(element).attr('aria-expanded', 'true');
                 $(element).attr('aria-label', 'Section ' + sectionName + ' expanded');
                 $(element).addClass('fa-angle-double-right');
                 $(element).removeClass('fa-angle-double-up');
-
-
             } else { // collapsed
                 $(element).attr('aria-expanded', 'false');
                 $(element).attr('aria-label', 'Section ' + sectionName + ' collapsed');

--- a/arches_her/media/js/bindings/reports.js
+++ b/arches_her/media/js/bindings/reports.js
@@ -2,26 +2,28 @@ define([
     'jquery',
     'knockout',
 ], function ($, ko) {
-    // apply aria attributes to the element when an observable changes between true and false
+    // Apply aria attributes to the element when an observable changes between true and false
     // e.g. <div data-bind="onReportSectionToggleAria: visible.names, sectionName: '{% trans "Section Name" %}'"></div>
     ko.bindingHandlers.onReportSectionToggleAria = {
         update: function (element, valueAccessor, allBindings) {
-            var value = ko.utils.unwrapObservable(valueAccessor());
-            var sectionName = allBindings.get('sectionName') || '';
-            if (value) { // section is expanded
-                $(element).attr('aria-expanded', 'true');
-                $(element).attr('aria-label', 'Section ' + sectionName + ' expanded');
-                $(element).addClass('fa-angle-double-right');
-                $(element).removeClass('fa-angle-double-up');
-            } else { // collapsed
-                $(element).attr('aria-expanded', 'false');
-                $(element).attr('aria-label', 'Section ' + sectionName + ' collapsed');
-                $(element).removeClass('fa-angle-double-right');
-                $(element).addClass('fa-angle-double-up');
+            const value = ko.utils.unwrapObservable(valueAccessor());
+            const sectionName = allBindings.get('sectionName') || '';
+
+            function setAriaAttributes(isExpanded) {
+                const ariaExpanded = isExpanded ? 'true' : 'false';
+                const ariaLabel = `Section ${sectionName} ${isExpanded ? 'expanded' : 'collapsed'}`;
+                const addClass = isExpanded ? 'fa-angle-double-right' : 'fa-angle-double-up';
+                const removeClass = isExpanded ? 'fa-angle-double-up' : 'fa-angle-double-right';
+
+                $(element).attr('aria-expanded', ariaExpanded);
+                $(element).attr('aria-label', ariaLabel);
+                $(element).addClass(addClass);
+                $(element).removeClass(removeClass);
             }
+
+            setAriaAttributes(value);
         }
     };
-
 
     return;
 });

--- a/arches_her/media/js/views/components/reports/scenes/name.js
+++ b/arches_her/media/js/views/components/reports/scenes/name.js
@@ -1,6 +1,6 @@
-define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable'], function(_, ko, arches, reportUtils) {
+define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable', 'bindings/reports'], function (_, ko, arches, reportUtils) {
     return ko.components.register('views/components/reports/scenes/name', {
-        viewModel: function(params) {
+        viewModel: function (params) {
             var self = this;
             Object.assign(self, reportUtils);
 
@@ -10,7 +10,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                     { "width": "50%" },
                     { "width": "20%" },
                     { "width": "20%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -21,7 +21,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                     { "width": "20%" },
                     { "width": "50%" },
                     { "width": "10%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -54,7 +54,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
             Object.assign(self.dataConfig, params.dataConfig || {});
 
             // if params.compiled is set and true, the user has compiled their own data.  Use as is.
-            if(params?.compiled){
+            if (params?.compiled) {
                 self.names(params.data.names);
                 self.crossReferences(params.data.crossReferences);
                 self.systemReferenceNumbers(params.data.referenceNumbers);
@@ -62,7 +62,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 const rawNameData = self.getRawNodeValue(params.data(), {
                     testPaths: [
                         ["names"],
-                        [self.dataConfig.name], 
+                        [self.dataConfig.name],
                         [`${self.dataConfig.name} names`]
                     ]
                 });
@@ -76,21 +76,24 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                                 [`${self.dataConfig.name} name use type`],
                                 [`${self.dataConfig.nameChildren} name use type`],
                                 [`${self.dataConfig.nameChildren} use type`]
-                            ]});
+                            ]
+                        });
                         const name = self.getNodeValue(x, {
                             testPaths: [
                                 ['name'],
                                 [`${self.dataConfig.name} name`],
                                 [`${self.dataConfig.nameChildren} name`],
                                 [`${self.dataConfig.nameChildren}`]
-                            ]});
+                            ]
+                        });
                         const currency = self.getNodeValue(x, {
                             testPaths: [
                                 ['name currency'],
                                 [`${self.dataConfig.name} name currency`],
                                 [`${self.dataConfig.nameChildren} name currency`],
                                 [`${self.dataConfig.nameChildren} currency`]
-                            ]});
+                            ]
+                        });
 
                         const tileid = self.getTileId(x);
                         return { name, nameUseType, currency, tileid }
@@ -104,7 +107,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                             "columns": [
                                 { "width": "70%" },
                                 { "width": "20%" },
-                            null,
+                                null,
                             ]
                         };
                     }
@@ -117,19 +120,21 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 });
                 const xrefData = rawXrefData ? Array.isArray(rawXrefData) ? rawXrefData : [rawXrefData] : undefined;
 
-                if(xrefData) {
+                if (xrefData) {
                     self.crossReferences(xrefData.map(x => {
-                        const name = self.getNodeValue(x,{
+                        const name = self.getNodeValue(x, {
                             testPaths: [
                                 ['external cross reference', '@display_value'],
                                 ['external cross reference']
-                            ]});
+                            ]
+                        });
                         const description = self.getNodeValue(x, {
                             testPaths: [
                                 ['external cross reference notes', 'external cross reference description', '@display_value'],
                                 ['external cross reference notes', 'external cross reference description']
-                            ]});
-                        
+                            ]
+                        });
+
                         const source = self.getNodeValue(x, {
                             testPaths: [
                                 ['external cross reference source', '@display_value'],
@@ -147,7 +152,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                         return { name, description, source, url, tileid }
                     }));
                 }
-            } 
+            }
 
             const systemRefData = self.getRawNodeValue(params.data(), {
                 testPaths: [
@@ -155,7 +160,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 ]
             });
 
-            if(systemRefData) {
+            if (systemRefData) {
                 const systemRef = {};
                 systemRef.resourceId = self.getNodeValue(systemRefData, 'uuid', 'resourceid');
                 systemRef.legacyId = self.getNodeValue(systemRefData, 'legacyid', 'legacy id');
@@ -164,7 +169,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 self.systemReferenceNumbers(systemRef);
             }
 
-            if(self.dataConfig.parent){
+            if (self.dataConfig.parent) {
                 self.parentData = ko.observable({
                     sections:
                         [
@@ -182,7 +187,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 });
             }
 
-            if(self.dataConfig.recordStatus){
+            if (self.dataConfig.recordStatus) {
                 self.recordStatusData = ko.observable({
                     sections:
                         [

--- a/arches_her/templates/views/components/reports/activity.htm
+++ b/arches_her/templates/views/components/reports/activity.htm
@@ -103,7 +103,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.activityArchive)}, css: {'fa-angle-double-right': visible.activityArchive(), 'fa-angle-double-up': !visible.activityArchive()}, attr: {'aria-expanded': visible.activityArchive() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Archive Material section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.activityArchive)}, onReportSectionToggleAria: visible.activityArchive, sectionName: '{% trans "Activity Archive Material" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Activity Archive Material" %}
                     </h2>
                     <!-- ko if: cards.activityArchive -->

--- a/arches_her/templates/views/components/reports/application-area.htm
+++ b/arches_her/templates/views/components/reports/application-area.htm
@@ -96,7 +96,11 @@
                 <!-- Application Area section -->
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.applicationAreas)}, css: {'fa-angle-double-right': visible.applicationAreas(), 'fa-angle-double-up': !visible.applicationAreas()}, attr: {'aria-expanded': visible.applicationAreas() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Application Areas section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.applicationAreas)}, onReportSectionToggleAria: visible.applicationAreas, sectionName: '{% trans "Associated Application Areas" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Associated Application Areas" %}
                     </h2>
                     <!-- ko if: cards.applicationAreas -->

--- a/arches_her/templates/views/components/reports/artefact.htm
+++ b/arches_her/templates/views/components/reports/artefact.htm
@@ -84,7 +84,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'discovery'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.discovery)}, css: {'fa-angle-double-right': visible.discovery(), 'fa-angle-double-up': !visible.discovery()}, attr: {'aria-expanded': visible.discovery() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Discovery section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.discovery)}, onReportSectionToggleAria: visible.discovery, sectionName: '{% trans "Discovery" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Discovery" %}
                     </h2>
                     <!-- ko if: cards.discovery -->
@@ -140,7 +144,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.finders)}, css: {'fa-angle-double-right': visible.finders(), 'fa-angle-double-up': !visible.finders()}, attr: {'aria-expanded': visible.finders() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Finders section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.finders)}, onReportSectionToggleAria: visible.finders, sectionName: '{% trans "Finders" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Finders" %}
                     </h2>
                     <span data-bind="if: cards.finders && (!finders().length || cards.finders.cardinality == 'n')">

--- a/arches_her/templates/views/components/reports/bibliographic-source.htm
+++ b/arches_her/templates/views/components/reports/bibliographic-source.htm
@@ -42,7 +42,11 @@
 
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.sourceNames)}, css: {'fa-angle-double-right': visible.sourceNames(), 'fa-angle-double-up': !visible.sourceNames()}, attr: {'aria-expanded': visible.sourceNames() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Names section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.sourceNames)}, onReportSectionToggleAria: visible.sourceNames, sectionName: '{% trans "Names" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Names" %}
                     </h2>
                     <span data-bind="if: cards.sourceNames && (!sourceNames().length || cards.sourceNames.cardinality == 'n')">
@@ -129,7 +133,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.publication)}, css: {'fa-angle-double-right': visible.publication(), 'fa-angle-double-up': !visible.publication()}, attr: {'aria-expanded': visible.publication() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Publication section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.publication)}, onReportSectionToggleAria: visible.publication, sectionName: '{% trans "Publication" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Publication" %}
                     </h2>
                     <span data-bind="if: cards.publication && (!publication().length || cards.publication.cardinality == 'n')">
@@ -185,7 +193,11 @@
                 <!-- Bibliographic Source Creation section -->
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.sourceCreation)}, css: {'fa-angle-double-right': visible.sourceCreation(), 'fa-angle-double-up': !visible.sourceCreation()}, attr: {'aria-expanded': visible.sourceCreation() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Source Creation section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.sourceCreation)}, onReportSectionToggleAria: visible.sourceCreation, sectionName: '{% trans "Source Creation" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Source Creation" %}
                     </h2>
                     <!-- ko if: cards.sourceCreation -->

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -931,7 +931,14 @@
     </div>
 
     <div class="aher-report-section">
-        <h2 class="aher-report-section-title"><i tabindex="0" data-bind="click: function() {toggleVisibility(visible.advice)}, css: {'fa-angle-double-right': visible.advice(), 'fa-angle-double-up': !visible.advice()}"  class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></i> {% trans "Advice" %}</h2>
+        <h2 class="aher-report-section-title">
+            <i
+                tabindex="0" 
+                data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.advice)}, onReportSectionToggleAria: visible.advice, sectionName: '{% trans "Advice" %}'"
+                class="fa toggle">
+            </i>
+            {% trans "Advice" %}
+        </h2>
         <a data-bind="{if: cards.advice, click: function(){addNewTile(cards.advice)}}" class="aher-report-a" href="#"><i class="fa fa-mail-reply"></i> {% trans "Add advice" %}</a>
 
         <!-- Collapsible content -->

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -79,7 +79,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'references'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.references)}, css: {'fa-angle-double-right': visible.references(), 'fa-angle-double-up': !visible.references()}, attr: {'aria-expanded': visible.references() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse External Cross References section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.references)}, onReportSectionToggleAria: visible.references, sectionName: '{% trans "External Cross References" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "External Cross References" %}
                     </h2>
                     <!-- ko if: cards['external cross references'] -->
@@ -135,7 +139,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.systemReferences)}, css: {'fa-angle-double-right': visible.systemReferences(), 'fa-angle-double-up': !visible.systemReferences()}, attr: {'aria-expanded': visible.systemReferences() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse External System References section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.systemReferences)}, onReportSectionToggleAria: visible.systemReferences, sectionName: '{% trans "External System References" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "External System References" %}
                     </h2>
                     <!-- ko if: cards['external system references'] -->
@@ -191,7 +199,11 @@
             <!-- Contacts Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'contacts'">
                 <h2 class="aher-report-section-title">
-                    <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.contacts)}, css: {'fa-angle-double-right': visible.contacts(), 'fa-angle-double-up': !visible.contacts()}, attr: {'aria-expanded': visible.contacts() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Contacts section"></i>
+                    <i
+                        tabindex="0" 
+                        data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.contacts)}, onReportSectionToggleAria: visible.contacts, sectionName: '{% trans "Contacts" %}'"
+                        class="fa toggle">
+                    </i>
                     {% trans "Contacts" %}
                 </h2>
                 <!-- ko if: cards.contacts -->
@@ -278,7 +290,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'progression'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.proposal)}, css: {'fa-angle-double-right': visible.proposal(), 'fa-angle-double-up': !visible.proposal()}, attr: {'aria-expanded': visible.proposal() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Proposal section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.proposal)}, onReportSectionToggleAria: visible.proposal, sectionName: '{% trans "Proposal" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Proposal" %}
                     </h2>
                     <!-- ko if: cards.proposal -->
@@ -330,7 +346,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.advice)}, css: {'fa-angle-double-right': visible.advice(), 'fa-angle-double-up': !visible.advice()}, attr: {'aria-expanded': visible.advice() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Advice section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.advice)}, onReportSectionToggleAria: visible.advice, sectionName: '{% trans "Advice" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Advice" %}
                     </h2>
                     <!-- ko if: cards.advice -->
@@ -383,7 +403,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.action)}, css: {'fa-angle-double-right': visible.action(), 'fa-angle-double-up': !visible.action()}, attr: {'aria-expanded': visible.action() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Action section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.action)}, onReportSectionToggleAria: visible.action, sectionName: '{% trans "Action" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Action" %}
                     </h2>
                     <!-- ko if: cards.actions -->
@@ -437,7 +461,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.outcomes)}, css: {'fa-angle-double-right': visible.outcomes(), 'fa-angle-double-up': !visible.outcomes()}, attr: {'aria-expanded': visible.outcomes() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Outcomes section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.outcomes)}, onReportSectionToggleAria: visible.outcomes, sectionName: '{% trans "Outcomes" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Outcomes" %}
                     </h2>
                     <!-- ko if: cards.outcomes -->
@@ -474,7 +502,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.assessmentOfSignificance)}, css: {'fa-angle-double-right': visible.assessmentOfSignificance(), 'fa-angle-double-up': !visible.assessmentOfSignificance()}, attr: {'aria-expanded': visible.assessmentOfSignificance() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Assessment of Significance section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.assessmentOfSignificance)}, onReportSectionToggleAria: visible.assessmentOfSignificance, sectionName: '{% trans "Assessment of Significance" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Assessment of Significance" %}
                     </h2>
                     <!-- ko if: cards['assessment of significance'] -->
@@ -527,7 +559,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'correspondence'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.correspondence)}, css: {'fa-angle-double-right': visible.correspondence(), 'fa-angle-double-up': !visible.correspondence()}, attr: {'aria-expanded': visible.correspondence() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Correspondence section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.correspondence)}, onReportSectionToggleAria: visible.correspondence, sectionName: '{% trans "Correspondence" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Correspondence" %}
                     </h2>
                     <!-- ko if: cards.correspondence -->
@@ -579,7 +615,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.communications)}, css: {'fa-angle-double-right': visible.communications(), 'fa-angle-double-up': !visible.communications()}, attr: {'aria-expanded': visible.communications() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Communications section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.communications)}, onReportSectionToggleAria: visible.communications, sectionName: '{% trans "Communications" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Communications" %}
                     </h2>
                     <!-- ko if: cards.communications -->
@@ -645,7 +685,11 @@
             <!-- Site Visit Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'sitevisits'">
                 <h2 class="aher-report-section-title">
-                    <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.siteVisits)}, css: {'fa-angle-double-right': visible.siteVisits(), 'fa-angle-double-up': !visible.siteVisits()}, attr: {'aria-expanded': visible.siteVisits() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Site Visits section"></i>
+                    <i
+                        tabindex="0" 
+                        data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.siteVisits)}, onReportSectionToggleAria: visible.siteVisits, sectionName: '{% trans "Site Visits" %}'"
+                        class="fa toggle">
+                    </i>
                     {% trans "Site Visits" %}
                 </h2>
                 <!-- ko if: cards['site visits'] -->
@@ -935,7 +979,11 @@
     </div>
 
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.contacts)}, css: {'fa-angle-double-right': visible.contacts(), 'fa-angle-double-up': !visible.contacts()}, attr: {'aria-expanded': visible.contacts() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Contacts section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.contacts)}, onReportSectionToggleAria: visible.contacts, sectionName: '{% trans "Contacts" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Contacts" %}
     </h2>
         <!-- ko if: cards.contacts -->

--- a/arches_her/templates/views/components/reports/digital-object.htm
+++ b/arches_her/templates/views/components/reports/digital-object.htm
@@ -61,7 +61,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'file'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}, attr: {'aria-expanded': visible.files() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Files section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.files)}, onReportSectionToggleAria: visible.files, sectionName: '{% trans "Files" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Files" %}
                     </h2>
                     <!-- ko if: cards['file'] -->

--- a/arches_her/templates/views/components/reports/historic-aircraft.htm
+++ b/arches_her/templates/views/components/reports/historic-aircraft.htm
@@ -91,7 +91,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'journey'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.flights)}, css: {'fa-angle-double-right': visible.flights(), 'fa-angle-double-up': !visible.flights()}, attr: {'aria-expanded': visible.flights() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Flights section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.flights)}, onReportSectionToggleAria: visible.flights, sectionName: '{% trans "Flights" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Flights" %}
                     </h2>
                     <!-- ko if: cards.flights -->
@@ -166,7 +170,11 @@
 
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.lastFlight)}, css: {'fa-angle-double-right': visible.lastFlight(), 'fa-angle-double-up': !visible.lastFlight()}, attr: {'aria-expanded': visible.lastFlight() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Last Flight section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.lastFlight)}, onReportSectionToggleAria: visible.lastFlight, sectionName: '{% trans "Last Flight" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Last Flight" %}
                     </h2>
                     <!-- ko if: cards.lastFlight -->

--- a/arches_her/templates/views/components/reports/historic-landscape-characterization.htm
+++ b/arches_her/templates/views/components/reports/historic-landscape-characterization.htm
@@ -83,7 +83,11 @@
                 <!-- HLC Phase section -->
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.historicLandscapeClassificationPhase)}, css: {'fa-angle-double-right': visible.historicLandscapeClassificationPhase(), 'fa-angle-double-up': !visible.historicLandscapeClassificationPhase()}, attr: {'aria-expanded': visible.historicLandscapeClassificationPhase() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse HLC Phase section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.historicLandscapeClassificationPhase)}, onReportSectionToggleAria: visible.historicLandscapeClassificationPhase, sectionName: '{% trans "HLC Phase" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "HLC Phase" %}
                     </h2>
                     <!-- ko if: cards.historicLandscapeClassificationPhase -->

--- a/arches_her/templates/views/components/reports/maritime-vessel.htm
+++ b/arches_her/templates/views/components/reports/maritime-vessel.htm
@@ -78,7 +78,11 @@
                 }"></div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.nationalities)}, css: {'fa-angle-double-right': visible.nationalities(), 'fa-angle-double-up': !visible.nationalities()}, attr: {'aria-expanded': visible.nationalities() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Nationalities section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.nationalities)}, onReportSectionToggleAria: visible.nationalities, sectionName: '{% trans "Nationalities" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Nationalities" %}
                     </h2>
                     <!-- ko if: cards.nationalities -->
@@ -132,7 +136,11 @@
                 </div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.owners)}, css: {'fa-angle-double-right': visible.owners(), 'fa-angle-double-up': !visible.owners()}, attr: {'aria-expanded': visible.owners() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Owners section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.owners)}, onReportSectionToggleAria: visible.owners, sectionName: '{% trans "Owners" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Owners" %}
                     </h2>
                     <!-- ko if: cards.owners -->
@@ -198,7 +206,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'journey'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.voyages)}, css: {'fa-angle-double-right': visible.voyages(), 'fa-angle-double-up': !visible.voyages()}, attr: {'aria-expanded': visible.voyages() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Voyages section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.voyages)}, onReportSectionToggleAria: visible.voyages, sectionName: '{% trans "Voyages" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Voyages" %}
                     </h2>
                     <!-- ko if: cards.voyages -->

--- a/arches_her/templates/views/components/reports/period.htm
+++ b/arches_her/templates/views/components/reports/period.htm
@@ -70,7 +70,11 @@
                 }"></div>
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.names)}, css: {'fa-angle-double-right': visible.names(), 'fa-angle-double-up': !visible.names()}, attr: {'aria-expanded': visible.names() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Alternative Names section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.names)}, onReportSectionToggleAria: visible.names, sectionName: '{% trans "Alternative Names" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Alternative Names" %}
                     </h2>
                     <span data-bind="if: cards.name && (!names().length || cards.name.cardinality == 'n')">

--- a/arches_her/templates/views/components/reports/person.htm
+++ b/arches_her/templates/views/components/reports/person.htm
@@ -40,7 +40,11 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'person-name'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title">
-                        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.names)}, css: {'fa-angle-double-right': visible.names(), 'fa-angle-double-up': !visible.names()}, attr: {'aria-expanded': visible.names() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Names section"></i>
+                        <i
+                            tabindex="0" 
+                            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.names)}, onReportSectionToggleAria: visible.names, sectionName: '{% trans "Names" %}'"
+                            class="fa toggle">
+                        </i>
                         {% trans "Names" %}
                     </h2>
                     <span data-bind="if: cards.names && (!names().length || cards.names.cardinality == 'n')">

--- a/arches_her/templates/views/components/reports/scenes/archive.htm
+++ b/arches_her/templates/views/components/reports/scenes/archive.htm
@@ -7,7 +7,11 @@
 <!-- Bibliographic Source Creation section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.sourceCreation">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.sourceCreation)}, css: {'fa-angle-double-right': visible.sourceCreation(), 'fa-angle-double-up': !visible.sourceCreation()}, attr: {'aria-expanded': visible.sourceCreation() ? 'false' : 'true' }"" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Source Creation section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.sourceCreation)}, onReportSectionToggleAria: visible.sourceCreation, sectionName: '{% trans "Source Creation" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Source Creation" %}
     </h2>
     <!-- ko if: cards.sourceCreation -->
@@ -65,7 +69,11 @@
 <!-- Repository Storage section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.repositoryStorage">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.repositoryStorage)}, css: {'fa-angle-double-right': visible.repositoryStorage(), 'fa-angle-double-up': !visible.repositoryStorage()}, attr: {'aria-expanded': visible.repositoryStorage() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Repository Storage Location section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.repositoryStorage)}, onReportSectionToggleAria: visible.repositoryStorage, sectionName: '{% trans "Repository Storage Location" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Repository Storage Location" %}
     </h2>
     <!-- ko if: cards.repositoryStorage -->

--- a/arches_her/templates/views/components/reports/scenes/assessments.htm
+++ b/arches_her/templates/views/components/reports/scenes/assessments.htm
@@ -6,7 +6,12 @@
 <!-- Artefact condition section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.artefactCondition">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.artefactCondition)}, css: {'fa-angle-double-right': visible.artefactCondition(), 'fa-angle-double-up': !visible.artefactCondition()}, attr: {'aria-expanded': visible.artefactCondition() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Artefact Condition section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.artefactCondition)}, onReportSectionToggleAria: visible.artefactCondition, sectionName: '{% trans "Artefact Condition" %}'"
+            class="fa toggle">
+        </i>
+
         {% trans "Artefact Condition" %}
     </h2>
     <!-- ko if: cards.artefactCondition -->
@@ -64,7 +69,11 @@
 <!-- Scientific date section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.scientificDate">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.scientificDate)}, css: {'fa-angle-double-right': visible.scientificDate(), 'fa-angle-double-up': !visible.scientificDate()}, attr: {'aria-expanded': visible.scientificDate() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Scientific Date Determination section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.scientificDate)}, onReportSectionToggleAria: visible.scientificDate, sectionName: '{% trans "Scientific Date Determination" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Scientific Date Determination" %}
     </h2>
     <!-- ko if: cards.scientificDate -->

--- a/arches_her/templates/views/components/reports/scenes/audit.htm
+++ b/arches_her/templates/views/components/reports/scenes/audit.htm
@@ -5,7 +5,11 @@
 {% block body %}
 <div class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.audit)}, css: {'fa-angle-double-right': visible.audit(), 'fa-angle-double-up': !visible.audit()}, attr: {'aria-expanded': visible.audit() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Audit Metadata section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.audit)}, onReportSectionToggleAria: visible.audit, sectionName: '{% trans "Audit Metadatan" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Audit Metadata" %}
     </h2>
     <span data-bind="if: cards.audit && (!audit() || cards.audit.cardinality == 'n')">

--- a/arches_her/templates/views/components/reports/scenes/classifications.htm
+++ b/arches_her/templates/views/components/reports/scenes/classifications.htm
@@ -18,7 +18,11 @@
 <!-- Construction Phases -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.artefactProduction">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.production)}, attr: {'aria-expanded': visible.production() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Production Phases section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.production)}, onReportSectionToggleAria: visible.production, sectionName: '{% trans "Production Phases" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Production Phases" %}
     </h2>
     <!-- ko if: cards.production -->
@@ -94,7 +98,11 @@
 <!-- Construction Phases -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.production">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.production)}, attr: {'aria-expanded': visible.production() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Construction Phases section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.production)}, onReportSectionToggleAria: visible.production, sectionName: '{% trans "Construction Phases" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Construction Phases" %}
     </h2>
     <!-- ko if: cards.production -->
@@ -176,7 +184,11 @@
 <!-- Construction Phases -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.aircraftProduction">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.production)}, attr: {'aria-expanded': visible.production() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Construction Phases section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.production)}, onReportSectionToggleAria: visible.production, sectionName: '{% trans "Construction Phases" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Construction Phases" %}
     </h2>
     <!-- ko if: cards.production -->
@@ -263,7 +275,11 @@
 <!-- Maritime Construction Phases -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.maritimeProduction">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.production)}, attr: {'aria-expanded': visible.production() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Construction Phases section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.production)}, onReportSectionToggleAria: visible.production, sectionName: '{% trans "Construction Phases" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Construction Phases" %}
     </h2>
     <!-- ko if: cards.production -->
@@ -354,7 +370,11 @@
 <!-- Dimensions -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.dimensions">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.dimensions)}, attr: {'aria-expanded': visible.dimensions() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Dimensions section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.dimensions)}, onReportSectionToggleAria: visible.dimensions, sectionName: '{% trans "Dimensions" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Dimensions" %}
     </h2>
     <!-- ko if: cards.dimensions -->
@@ -413,7 +433,11 @@
 <!-- Components -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.components">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.components)}, attr: {'aria-expanded': visible.components() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Construction Components section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.components)}, onReportSectionToggleAria: visible.components, sectionName: '{% trans "Construction Components" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Construction Components" %}
     </h2>
     <!-- ko if: cards.components -->
@@ -474,7 +498,11 @@
 <!-- Use Phases -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.usePhase">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.usePhase)}, attr: {'aria-expanded': visible.usePhase() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Use Phases section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.usePhase)}, onReportSectionToggleAria: visible.usePhase, sectionName: '{% trans "Use Phases" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Use Phases" %}
     </h2>
     <!-- ko if: cards.usePhase -->
@@ -547,7 +575,11 @@
 <!-- Dates -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.organizationFormation">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.organizationFormation)}, attr: {'aria-expanded': visible.organizationFormation() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Organization Formation section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.organizationFormation)}, onReportSectionToggleAria: visible.organizationFormation, sectionName: '{% trans "Organization Formation" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Organization Formation" %}
     </h2>
     <!-- ko if: cards.organizationFormation -->
@@ -610,7 +642,11 @@
 <!-- Dates -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.dates">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.dates)}, attr: {'aria-expanded': visible.dates() ? 'false' : 'true' }" class="fa fa-angle-double-right toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Dates section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.dates)}, onReportSectionToggleAria: visible.dates, sectionName: '{% trans "Dates" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Dates" %}
     </h2>
     <!-- ko if: cards.dates -->

--- a/arches_her/templates/views/components/reports/scenes/contact.htm
+++ b/arches_her/templates/views/components/reports/scenes/contact.htm
@@ -5,7 +5,11 @@
 {% block body %}
 <div class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.contact)}, css: {'fa-angle-double-right': visible.contact(), 'fa-angle-double-up': !visible.contact()}, attr: {'aria-expanded': visible.contact() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Contact Details section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.contact)}, onReportSectionToggleAria: visible.contact, sectionName: '{% trans "Contact Details" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Contact Details" %}
     </h2>
     <span data-bind="if: cards.contact && (!contact().length || cards.contact.cardinality == 'n')">

--- a/arches_her/templates/views/components/reports/scenes/copyright.htm
+++ b/arches_her/templates/views/components/reports/scenes/copyright.htm
@@ -5,7 +5,11 @@
 {% block body %}
 <div class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.copyright)}, css: {'fa-angle-double-right': visible.copyright(), 'fa-angle-double-up': !visible.copyright()}, attr: {'aria-expanded': visible.copyright() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Copyright section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.copyright)}, onReportSectionToggleAria: visible.copyright, sectionName: '{% trans "Copyright" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Copyright" %}
     </h2>
     <span data-bind="if: cards.copyright && (!copyright().length || cards.copyright.cardinality == 'n')">

--- a/arches_her/templates/views/components/reports/scenes/default.htm
+++ b/arches_her/templates/views/components/reports/scenes/default.htm
@@ -10,7 +10,7 @@
             data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(section.title)}, onReportSectionToggleAria: section.title, sectionName: '{% trans section.title() %}'"
             class="fa toggle">
         </i>
-        <span data-bind="text: section.title"></span>
+        {% trans section.title() %}
     </h2>
     <span data-bind="if: section.card && section.card.cardinality == '1'">
         <a href="#" class="aher-report-a" data-bind="click: function(){add(section.card)}"><i class="fa fa-mail-reply"></i> {% trans "Edit" %} <span style="text-transform: capitalize;" data-bind="text:section.title"></span></a>

--- a/arches_her/templates/views/components/reports/scenes/default.htm
+++ b/arches_her/templates/views/components/reports/scenes/default.htm
@@ -5,7 +5,11 @@
 {% block body %}
 <div class="aher-report-section" data-bind="foreach: {data: sections, as: 'section', noChildContext: true}">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible[section.title])}, css: {'fa-angle-double-right': visible[section.title](), 'fa-angle-double-up': !visible[section.title]()}, attr: {'aria-expanded': visible[section.title]() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(section.title)}, onReportSectionToggleAria: section.title, sectionName: '{% trans section.title() %}'"
+            class="fa toggle">
+        </i>
         <span data-bind="text: section.title"></span>
     </h2>
     <span data-bind="if: section.card && section.card.cardinality == '1'">

--- a/arches_her/templates/views/components/reports/scenes/default.htm
+++ b/arches_her/templates/views/components/reports/scenes/default.htm
@@ -7,10 +7,10 @@
     <h2 class="aher-report-section-title">
         <i
             tabindex="0" 
-            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(section.title)}, onReportSectionToggleAria: section.title, sectionName: '{% trans section.title() %}'"
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible[section.title])}, onReportSectionToggleAria: visible[section.title], sectionName: section.title"
             class="fa toggle">
         </i>
-        {% trans section.title() %}
+        <span data-bind="text: section.title"></span>
     </h2>
     <span data-bind="if: section.card && section.card.cardinality == '1'">
         <a href="#" class="aher-report-a" data-bind="click: function(){add(section.card)}"><i class="fa fa-mail-reply"></i> {% trans "Edit" %} <span style="text-transform: capitalize;" data-bind="text:section.title"></span></a>

--- a/arches_her/templates/views/components/reports/scenes/description.htm
+++ b/arches_her/templates/views/components/reports/scenes/description.htm
@@ -5,7 +5,11 @@
 {% block body %}
 <div class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.descriptions)}, css: {'fa-angle-double-right': visible.descriptions(), 'fa-angle-double-up': !visible.descriptions()}, attr: {'aria-expanded': visible.descriptions() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Descriptions section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.descriptions)}, onReportSectionToggleAria: visible.descriptions, sectionName: '{% trans "Descriptions" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Descriptions" %}
     </h2>
     <span data-bind="if: cards.descriptions && (!descriptions().length || cards.descriptions.cardinality == 'n')">
@@ -57,7 +61,11 @@
 </div>
 <div class="aher-report-section" data-bind="visible: !!dataConfig.citation">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.citation)}, css: {'fa-angle-double-right': visible.citation(), 'fa-angle-double-up': !visible.citation()}, attr: {'aria-expanded': visible.citation() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Citations section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.citation)}, onReportSectionToggleAria: visible.citation, sectionName: '{% trans "Citations" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Citations" %}
     </h2>
     <span data-bind="if: cards.citation && (!citations() || cards.citation.cardinality == 'n')">
@@ -118,7 +126,11 @@
 <!-- Audience section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.audience">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.audience)}, css: {'fa-angle-double-right': visible.audience(), 'fa-angle-double-up': !visible.audience()}, attr: {'aria-expanded': visible.audience() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Audience section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.audience)}, onReportSectionToggleAria: visible.audience, sectionName: '{% trans "Audience" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Audience" %}
     </h2>
     <!-- ko if: cards.audience -->

--- a/arches_her/templates/views/components/reports/scenes/images.htm
+++ b/arches_her/templates/views/components/reports/scenes/images.htm
@@ -6,7 +6,11 @@
 <!-- Copyright section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.copyright">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.copyright)}, css: {'fa-angle-double-right': visible.copyright(), 'fa-angle-double-up': !visible.copyright()}, attr: {'aria-expanded': visible.copyright() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Copyrights section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.copyright)}, onReportSectionToggleAria: visible.copyright, sectionName: '{% trans "Copyrights" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Copyrights" %}
     </h2>
     <!-- ko if: cards.copyright -->
@@ -59,7 +63,11 @@
 
 <div class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.images)}, css: {'fa-angle-double-right': visible.images(), 'fa-angle-double-up': !visible.images()}, attr: {'aria-expanded': visible.images() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Images section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.images)}, onReportSectionToggleAria: visible.images, sectionName: '{% trans "Images" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Images" %}
     </h2>
     <!-- ko if: cards.images -->

--- a/arches_her/templates/views/components/reports/scenes/json.htm
+++ b/arches_her/templates/views/components/reports/scenes/json.htm
@@ -6,7 +6,11 @@
 <!-- JSON section -->
 <div class="aher-report-section aher-flex-col">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.json)}, css: {'fa-angle-double-right': visible.json(), 'fa-angle-double-up': !visible.json()}, attr: {'aria-expanded': visible.json() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Resource JSON section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.json)}, onReportSectionToggleAria: visible.json, sectionName: '{% trans "Resource JSON" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Resource JSON" %}
     </h2>
     

--- a/arches_her/templates/views/components/reports/scenes/location.htm
+++ b/arches_her/templates/views/components/reports/scenes/location.htm
@@ -24,7 +24,17 @@
 
         <div class="aher-report-subsection">
             <div class="aher-report-subsection-container no-flex map-container">
-                <h3><i data-bind="css: {'fa-angle-double-right': visible.geometry(), 'fa-angle-double-up': !visible.geometry()}" class="fa toggle"></i> {% trans "Geometry " %}  <span data-bind="visible: observableValueSet([geometryShape])">(Shape type: <span data-bind="text: geometryShape"></span>)</span></h3>
+                <h3>
+                    <i
+                        tabindex="0" 
+                        data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.geometry)}, onReportSectionToggleAria: visible.geometry, sectionName: '{% trans "Geometry" %}'"
+                        class="fa toggle">
+                    </i>
+                    {% trans "Geometry" %}  
+                    <span data-bind="visible: observableValueSet([geometryShape])">
+                        (Shape type: <span data-bind="text: geometryShape"></span>)
+                    </span>
+                </h3>
                 <!-- ko if: cards.locationGeometry -->
                 <a href="#" class="aher-report-a" data-bind="click: function(){addNewTile(cards.locationGeometry)}"><i class="fa fa-mail-reply"></i> {% trans "Edit location" %}</a>
                 <!-- /ko -->
@@ -36,7 +46,14 @@
                         }}">
                     </div>
                 </div>
-                <h3 class=""><i tabindex="0" data-bind="click: function() {toggleVisibility(visible.geometryMetadata)}, css: {'fa-angle-double-right': visible.geometryMetadata(), 'fa-angle-double-up': !visible.geometryMetadata()}" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></i> {% trans "Geometry Metadata" %}</h3>
+                <h3 class="">
+                    <i
+                        tabindex="0" 
+                        data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.geometryMetadata)}, onReportSectionToggleAria: visible.geometryMetadata, sectionName: '{% trans "Geometry Metadata" %}'"
+                        class="fa toggle">
+                    </i>
+                    {% trans "Geometry Metadata" %}
+                </h3>
                 <div class="" data-bind="if: visible.geometryMetadata">
                     <!-- Record Authorization/Compilation/Update -->
                     <div class="aher-report-subsection-firstchild no-top-pad">

--- a/arches_her/templates/views/components/reports/scenes/location.htm
+++ b/arches_her/templates/views/components/reports/scenes/location.htm
@@ -6,7 +6,11 @@
 <!-- Geometry/Map -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.geometry">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.coordinates)}, css: {'fa-angle-double-right': visible.coordinates(), 'fa-angle-double-up': !visible.coordinates()}, attr: {'aria-expanded': visible.coordinates() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Geospatial Coordinates section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.coordinates)}, onReportSectionToggleAria: visible.coordinates, sectionName: '{% trans "Geospatial Coordinates" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Geospatial Coordinates" %}
     </h2>
     <!-- ko if: cards.locationGeometry && !coordinateData || locationRoot -->
@@ -142,7 +146,11 @@
 <!-- Addresses -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.addresses">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.addresses)}, css: {'fa-angle-double-right': visible.addresses(), 'fa-angle-double-up': !visible.addresses()}, attr: {'aria-expanded': visible.addresses() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Addresses section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.addresses)}, onReportSectionToggleAria: visible.addresses, sectionName: '{% trans "Addresses" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Addresses" %}
     </h2>
     <!-- ko if: cards.addresses || locationRoot -->
@@ -220,7 +228,11 @@
 <!-- Location Description -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.locationDescription">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.descriptions)}, css: {'fa-angle-double-right': visible.descriptions(), 'fa-angle-double-up': !visible.descriptions()}, attr: {'aria-expanded': visible.descriptions() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Location Descriptions section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.descriptions)}, onReportSectionToggleAria: visible.descriptions, sectionName: '{% trans "Location Descriptions" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Location Descriptions" %}
     </h2>
     <!-- ko if: cards.locationDescriptions || locationRoot -->
@@ -276,7 +288,11 @@
 <!-- Admin Areas -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.administrativeAreas">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.administrativeAreas)}, css: {'fa-angle-double-right': visible.administrativeAreas(), 'fa-angle-double-up': !visible.administrativeAreas()}, attr: {'aria-expanded': visible.administrativeAreas() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Administrative Areas section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.administrativeAreas)}, onReportSectionToggleAria: visible.administrativeAreas, sectionName: '{% trans "Administrative Areas" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Administrative Areas" %}
     </h2>
     <!-- ko if: cards.administrativeAreas || locationRoot -->
@@ -334,7 +350,11 @@
 <!-- National Grid References -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.nationalGrid">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.nationalGrid)}, css: {'fa-angle-double-right': visible.nationalGrid(), 'fa-angle-double-up': !visible.nationalGrid()}, attr: {'aria-expanded': visible.nationalGrid() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse National Grid References section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.nationalGrid)}, onReportSectionToggleAria: visible.nationalGrid, sectionName: '{% trans "National Grid References" %}'"
+            class="fa toggle">
+        </i>
         {% trans "National Grid References" %}
     </h2>
     <!-- ko if: cards.nationalGridReferences || locationRoot -->
@@ -388,7 +408,11 @@
 <!-- Named Locations -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.namedLocations">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.namedLocations)}, css: {'fa-angle-double-right': visible.namedLocations(), 'fa-angle-double-up': !visible.namedLocations()}, attr: {'aria-expanded': visible.namedLocations() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Named Locations section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.namedLocations)}, onReportSectionToggleAria: visible.namedLocations, sectionName: '{% trans "Named Locations" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Named Locations" %}
     </h2>
     <!-- ko if: cards.namedLocations || locationRoot -->

--- a/arches_her/templates/views/components/reports/scenes/name.htm
+++ b/arches_her/templates/views/components/reports/scenes/name.htm
@@ -112,7 +112,7 @@
 <!-- External Reference -->
 <!-- ko ifnot: hideCrossReferences() -->
 <div data-bind="visible: !!dataConfig.xref" class="aher-report-section">
-    <h2 class="aher-report-section-title">
+    <h2 class="aher-report-section-title" data-rob="name.htm">
         <i
             tabindex="0"
             data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.crossReferences)}, onReportSectionToggleAria: visible.crossReferences, sectionName: '{% trans "External Cross References" %}'"
@@ -188,7 +188,7 @@
 
 <!-- System Reference Numbers section -->
 <div class="aher-report-section">
-    <h2 class="aher-report-section-title">
+    <h2 class="aher-report-section-title" data-rob="name.htm">
         <i 
             tabindex="0" 
             data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.systemReferenceNumbers)}, onReportSectionToggleAria: visible.systemReferenceNumbers, sectionName: '{% trans "System Reference Numbers" %}'" 

--- a/arches_her/templates/views/components/reports/scenes/name.htm
+++ b/arches_her/templates/views/components/reports/scenes/name.htm
@@ -6,11 +6,16 @@
 <!-- ko ifnot: hideNames() -->
 <div data-bind="visible: !!dataConfig.name" class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.names)}, css: {'fa-angle-double-right': visible.names(), 'fa-angle-double-up': !visible.names()}, attr: {'aria-expanded': visible.names() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Names section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.names)}, onReportSectionToggleAria: visible.names, sectionName: '{% trans "Names" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Names" %}
     </h2>
     <span data-bind="if: cards.name && (!names().length || cards.name.cardinality == 'n')">
-        <a href="#" class="aher-report-a" data-bind="click: function(){add(cards.name)}"><i class="fa fa-mail-reply"></i> {% trans "Add Name" %}</a>
+        <a href="#" class="aher-report-a" data-bind="click: function(){add(cards.name)}"><i
+                class="fa fa-mail-reply"></i> {% trans "Add Name" %}</a>
     </span>
 
     <!-- Collapsible content -->
@@ -22,7 +27,7 @@
 
         <!-- ko if: names().length -->
         <!-- ko if: showCurrency() -->
-        <div class="aher-report-subsection" >
+        <div class="aher-report-subsection">
             <div>
                 <div class="aher-table pad-btm">
                     <p class="aher-table-aria-describedby" id="names-table_info">Name table.</p>
@@ -42,10 +47,14 @@
                                 <td data-bind="text: currency"></td>
                                 <td class="aher-table-control">
                                     <div data-bind="if: $parent.cards && $parent.cards.name">
-                                        <a href="#" data-bind="click: function() {$parent.edit(tileid, $parent.cards.name)}" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
+                                        <a href="#"
+                                            data-bind="click: function() {$parent.edit(tileid, $parent.cards.name)}"
+                                            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-mail-reply"></i>
                                         </a>
-                                        <a href="#" data-bind="click: $parent.deleteTile.bind($data, tileid, $parent.cards.name)" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
+                                        <a href="#"
+                                            data-bind="click: $parent.deleteTile.bind($data, tileid, $parent.cards.name)"
+                                            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-trash"></i>
                                         </a>
                                     </div>
@@ -58,7 +67,7 @@
         </div>
         <!-- /ko -->
         <!-- ko ifnot: showCurrency() -->
-        <div class="aher-report-subsection" >
+        <div class="aher-report-subsection">
             <div>
                 <div class="aher-table pad-btm">
                     <p class="aher-table-aria-describedby" id="name-use-type-table_info">Name use type table.</p>
@@ -76,10 +85,14 @@
                                 <td data-bind="text: nameUseType"></td>
                                 <td class="aher-table-control">
                                     <div data-bind="if: $parent.cards && $parent.cards.name">
-                                        <a href="#" data-bind="click: function() {$parent.edit(tileid, $parent.cards.name)}" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
+                                        <a href="#"
+                                            data-bind="click: function() {$parent.edit(tileid, $parent.cards.name)}"
+                                            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-mail-reply"></i>
                                         </a>
-                                        <a href="#" data-bind="click: $parent.deleteTile.bind($data, tileid, $parent.cards.name)" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
+                                        <a href="#"
+                                            data-bind="click: $parent.deleteTile.bind($data, tileid, $parent.cards.name)"
+                                            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-trash"></i>
                                         </a>
                                     </div>
@@ -100,11 +113,16 @@
 <!-- ko ifnot: hideCrossReferences() -->
 <div data-bind="visible: !!dataConfig.xref" class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.crossReferences)}, css: {'fa-angle-double-right': visible.crossReferences(), 'fa-angle-double-up': !visible.crossReferences()}, attr: {'aria-expanded': visible.crossReferences() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse External Cross References section"></i>
+        <i
+            tabindex="0"
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.crossReferences)}, onReportSectionToggleAria: visible.crossReferences, sectionName: '{% trans "External Cross References" %}'"
+            class="fa toggle">
+        </i> 
         {% trans "External Cross References" %}
     </h2>
     <!-- ko if: cards.externalCrossReferences -->
-    <a href="#" data-bind="click: function(){addNewTile(cards.externalCrossReferences)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Reference" %}</a>
+    <a href="#" data-bind="click: function(){addNewTile(cards.externalCrossReferences)}" class="aher-report-a"><i
+            class="fa fa-mail-reply"></i> {% trans "Add Reference" %}</a>
     <!-- /ko -->
 
     <!-- Collapsible content -->
@@ -117,8 +135,10 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table">
-                    <p class="aher-table-aria-describedby" id="external-cross-references-table_info">External cross reference table.</p>
-                    <table id="external-cross-references-table" class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="external-cross-references-table_info">External cross
+                        reference table.</p>
+                    <table id="external-cross-references-table" class="table table-striped" cellspacing="0"
+                        width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Name" %}</th>
@@ -128,7 +148,8 @@
                                 <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
-                        <tbody data-bind="dataTablesForEach: {data: crossReferences, dataTableOptions: crossReferenceTableConfig}">
+                        <tbody
+                            data-bind="dataTablesForEach: {data: crossReferences, dataTableOptions: crossReferenceTableConfig}">
                             <tr>
                                 <td data-bind="text: name"></td>
                                 <td data-bind="text: source"></td>
@@ -142,10 +163,14 @@
                                 </td>
                                 <td class="aher-table-control">
                                     <div data-bind="if: $parent.cards.externalCrossReferences">
-                                        <a href="#" data-bind="click: function(){$parent.editTile(tileid, $parent.cards.externalCrossReferences)}" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
+                                        <a href="#"
+                                            data-bind="click: function(){$parent.editTile(tileid, $parent.cards.externalCrossReferences)}"
+                                            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-mail-reply"></i>
                                         </a>
-                                        <a href="#" data-bind="click: $parent.deleteTile.bind($data, tileid, $parent.cards.externalCrossReferences)" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
+                                        <a href="#"
+                                            data-bind="click: $parent.deleteTile.bind($data, tileid, $parent.cards.externalCrossReferences)"
+                                            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-trash"></i>
                                         </a>
                                     </div>
@@ -164,7 +189,11 @@
 <!-- System Reference Numbers section -->
 <div class="aher-report-section">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.systemReferenceNumbers)}, css: {'fa-angle-double-right': visible.systemReferenceNumbers(), 'fa-angle-double-up': !visible.systemReferenceNumbers()}, attr: {'aria-expanded': visible.systemReferenceNumbers() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse System Reference Numbers section"></i>
+        <i 
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.systemReferenceNumbers)}, onReportSectionToggleAria: visible.systemReferenceNumbers, sectionName: '{% trans "System Reference Numbers" %}'" 
+            class="fa toggle">
+        </i> 
         {% trans "System Reference Numbers" %}
     </h2>
     <!-- ko if: cards.systemReferenceNumbers -->
@@ -225,7 +254,7 @@
 {% block summary %}
 
 <div class="model-summary-report">
-Do not use - yet.
+    Do not use - yet.
 </div>
 
 {% endblock summary %}

--- a/arches_her/templates/views/components/reports/scenes/people.htm
+++ b/arches_her/templates/views/components/reports/scenes/people.htm
@@ -5,9 +5,12 @@
 {% block body %}
 <!-- Associated Actors -->
 <div class="aher-report-section">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.people)}, css: {'fa-angle-double-right': visible.people(), 'fa-angle-double-up': !visible.people()}" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated People and Organizations section"></i>
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.people)}, css: {'fa-angle-double-right': visible.people(), 'fa-angle-double-up': !visible.people()}, attr: {'aria-expanded': visible.people() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated People and Organizations section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.people)}, onReportSectionToggleAria: visible.people, sectionName: '{% trans "Associated People and Organizations" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated People and Organizations" %}
     </h2>
     <!-- ko if: cards.people -->

--- a/arches_her/templates/views/components/reports/scenes/protection.htm
+++ b/arches_her/templates/views/components/reports/scenes/protection.htm
@@ -6,8 +6,12 @@
 <!-- Geometry/Map -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.protection">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.geospatial)}, css: {'fa-angle-double-right': visible.geospatial(), 'fa-angle-double-up': !visible.geospatial()}, attr: {'aria-expanded': visible.geospatial() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Designation/Protection section"></i>
-        {% trans "Designation/Protection " %}
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.geospatial)}, onReportSectionToggleAria: visible.geospatial, sectionName: '{% trans "Designation/Protection" %}'"
+            class="fa toggle">
+        </i>
+        {% trans "Designation/Protection" %}
     </h2>
     <!-- ko if: cards.designations -->
     <a href="#" class="aher-report-a" data-bind="click: function(){addNewTile(cards.designations)}">
@@ -101,7 +105,11 @@
 <!-- Area Assignments -->
 <div class="aher-report-section" data-bind="if: dataConfig.areaAssignment">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.areaAssignment)}, css: {'fa-angle-double-right': visible.areaAssignment(), 'fa-angle-double-up': !visible.areaAssignment()}, attr: {'aria-expanded': visible.areaAssignment() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Area Assignment section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.areaAssignment)}, onReportSectionToggleAria: visible.areaAssignment, sectionName: '{% trans "Area Assignment" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Area Assignment" %}
     </h2>
     <!-- ko if: cards.areaAssignment || locationRoot -->
@@ -167,7 +175,11 @@
 <!-- Land Use Classification -->
 <div class="aher-report-section" data-bind="if: dataConfig.landUse">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.landUse)}, css: {'fa-angle-double-right': visible.landUse(), 'fa-angle-double-up': !visible.landUse()}, attr: {'aria-expanded': visible.landUse() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Land Use Classification section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.landUse)}, onReportSectionToggleAria: visible.landUse, sectionName: '{% trans "Land Use Classification" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Land Use Classification" %}
     </h2>
     <!-- ko if: cards.landUse || locationRoot -->

--- a/arches_her/templates/views/components/reports/scenes/protection.htm
+++ b/arches_her/templates/views/components/reports/scenes/protection.htm
@@ -23,7 +23,14 @@
     <div data-bind="visible: visible.geospatial" class="aher-report-collapsible-container pad-lft">
 
         <div class="aher-report-subsection" data-bind="if: geojson() && geojson().features.length">
-            <h3><i data-bind="click: function() {toggleVisibility(visible.map)}, css: {'fa-angle-double-right': visible.map(), 'fa-angle-double-up': !visible.map()}" class="fa toggle"></i> {% trans "Geometry " %}</h3>
+            <h3>
+                <i
+                    tabindex="0" 
+                    data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.map)}, onReportSectionToggleAria: visible.map, sectionName: '{% trans "Geometry" %}'"
+                    class="fa toggle">
+                </i>
+                {% trans "Geometry " %}
+            </h3>
             <!-- ko if: cards.locationGeometry -->
             <a href="#" class="aher-report-a" data-bind="click: function(){addNewTile(cards.locationGeometry)}"><i class="fa fa-mail-reply"></i> {% trans "Edit location" %}</a>
             <!-- /ko -->
@@ -39,7 +46,14 @@
         </div>
         <!-- Designation Records -->
         <div class="aher-report-subsection">
-            <h3><i data-bind="click: function() {toggleVisibility(visible.designations)}, css: {'fa-angle-double-right': visible.designations(), 'fa-angle-double-up': !visible.designations()}" class="fa toggle"></i> {% trans "Designation/Protection Details " %}</h3>
+            <h3>
+                <i
+                    tabindex="0" 
+                    data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.designations)}, onReportSectionToggleAria: visible.designations, sectionName: '{% trans "Designation/Protection Details" %}'"
+                    class="fa toggle">
+                </i>
+                {% trans "Designation/Protection Details" %}
+            </h3>
             <div data-bind="visible: visible.designations">
                 <!-- ko ifnot: designations().length -->
                 <div class="aher-nodata-note">No designation information for this resource</div>

--- a/arches_her/templates/views/components/reports/scenes/referenced-by.htm
+++ b/arches_her/templates/views/components/reports/scenes/referenced-by.htm
@@ -4,7 +4,14 @@
 
 {% block body %}
 
-<h2 class="aher-report-section-title"><i tabindex="0" data-bind="click: function() {toggleVisibility(visible.referencedBy)}, css: {'fa-angle-double-right': visible.referencedBy(), 'fa-angle-double-up': !visible.referencedBy()}, attr: {'aria-expanded': visible.referencedBy() ? 'false' : 'true' }"  class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Referenced By section"></i> {% trans "Resource Referenced By" %}</h2>
+<h2 class="aher-report-section-title">
+    <i
+        tabindex="0" 
+        data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.referencedBy)}, onReportSectionToggleAria: visible.referencedBy, sectionName: '{% trans "Resource Referenced By" %}'"
+        class="fa toggle">
+    </i>
+    {% trans "Resource Referenced By" %}
+</h2>
 <!-- Collapsible content -->
 <div data-bind="visible: visible.referencedBy" class="aher-report-collapsible-container pad-lft">
 

--- a/arches_her/templates/views/components/reports/scenes/resources.htm
+++ b/arches_her/templates/views/components/reports/scenes/resources.htm
@@ -6,7 +6,11 @@
 <!-- Associated Activities section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.activities">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.activities)}, css: {'fa-angle-double-right': visible.activities(), 'fa-angle-double-up': !visible.activities()}, attr: {'aria-expanded': visible.activities() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Activities section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.activities)}, onReportSectionToggleAria: visible.activities, sectionName: '{% trans "Associated Activities" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated Activities" %}
     </h2>
     <!-- ko if: cards.activities -->
@@ -66,7 +70,11 @@
 <!-- Associated Archive section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.archive">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.archive)}, css: {'fa-angle-double-right': visible.archive(), 'fa-angle-double-up': !visible.archive()}, attr: {'aria-expanded': visible.archive() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Archive Objects section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.archive)}, onReportSectionToggleAria: visible.archive, sectionName: '{% trans "Associated Archive Objects" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated Archive Objects" %}
     </h2>
     <!-- ko if: cards.archive -->
@@ -130,7 +138,11 @@
 <!-- Associated Consultations section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.consultations">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.consultations)}, css: {'fa-angle-double-right': visible.consultations(), 'fa-angle-double-up': !visible.consultations()}, attr: {'aria-expanded': visible.consultations() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Consultations section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.consultations)}, onReportSectionToggleAria: visible.consultations, sectionName: '{% trans "Associated Consultations" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated Consultations" %}
     </h2>
     <!-- ko if: cards.consultations -->
@@ -191,7 +203,11 @@
 <!-- Associated Digital Files section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.files">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}, attr: {'aria-expanded': visible.files() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Files section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.files)}, onReportSectionToggleAria: visible.files, sectionName: '{% trans "Associated Files" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated Files" %}
     </h2>
     <!-- ko if: cards.files -->
@@ -250,7 +266,11 @@
 <!-- Associated Monuments section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.assets">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.assets)}, css: {'fa-angle-double-right': visible.assets(), 'fa-angle-double-up': !visible.assets()}, attr: {'aria-expanded': visible.assets() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Monuments/Areas/Artefacts section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.assets)}, onReportSectionToggleAria: visible.assets, sectionName: '{% trans "Associated Monuments/Areas/Artefacts" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated Monuments/Areas/Artefacts" %}
     </h2>
     <!-- ko if: cards.assets -->
@@ -313,7 +333,11 @@
 <!-- Associated People and Organisations section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.actors">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.actors)}, css: {'fa-angle-double-right': visible.actors(), 'fa-angle-double-up': !visible.actors()}, attr: {'aria-expanded': visible.actors() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated People and Organisations section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.actors)}, onReportSectionToggleAria: visible.actors, sectionName: '{% trans "Associated People and Organisations" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Associated People and Organisations" %}
     </h2>
     <!-- ko if: cards.actors -->
@@ -373,7 +397,11 @@
 <!-- Related Application Area section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.relatedApplicationArea">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.applicationArea)}, css: {'fa-angle-double-right': visible.applicationArea(), 'fa-angle-double-up': !visible.applicationArea()}, attr: {'aria-expanded': visible.applicationArea() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Related Application Areas section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.applicationArea)}, onReportSectionToggleAria: visible.applicationArea, sectionName: '{% trans "Related Application Areas" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Related Application Areas" %}
     </h2>
     <!-- Collapsible content -->
@@ -424,7 +452,11 @@
 <!-- Translation section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.translation">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.translation)}, css: {'fa-angle-double-right': visible.translation(), 'fa-angle-double-up': !visible.translation()}, attr: {'aria-expanded': visible.translation() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Translations section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.translation)}, onReportSectionToggleAria: visible.translation, sectionName: '{% trans "Translations" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Translations" %}
     </h2>
     <!-- ko if: cards.translation -->
@@ -476,7 +508,11 @@
 <!-- Period section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.period">
     <h2 class="aher-report-section-title">
-        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.period)}, css: {'fa-angle-double-right': visible.period(), 'fa-angle-double-up': !visible.period()}, attr: {'aria-expanded': visible.period() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Periods section"></i>
+        <i
+            tabindex="0" 
+            data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.period)}, onReportSectionToggleAria: visible.period, sectionName: '{% trans "Periods" %}'"
+            class="fa toggle">
+        </i>
         {% trans "Periods" %}
     </h2>
     <!-- ko if: cards.period -->


### PR DESCRIPTION
[AB#71898](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/71898)

Widespread markup changes for screen-reader to work better with toggling chevrons. For example, from:

```javascript
<i tabindex="0" data-bind="click: function() {toggleVisibility(visible.discovery)}, css: {'fa-angle-double-right': visible.discovery(), 'fa-angle-double-up': !visible.discovery()}, attr: {'aria-expanded': visible.discovery() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Discovery section"></i>
```

....to...

```javascript
<i
    tabindex="0" 
    data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.discovery)}, onReportSectionToggleAria: visible.discovery, sectionName: '{% trans "Discovery" %}'"
    class="fa toggle">
</i>
```