### PR TITLE
AB#73553 Fix featurette6 alignment issue on mac

### DIFF
--- a/arches_her/media/css/branding.css
+++ b/arches_her/media/css/branding.css
@@ -656,6 +656,10 @@
     margin-top: 30px;
 }
 
+.featurette6-row .featurette-image-block {
+    max-width: 423px;
+}
+
 .featurette7 .jumbotron {
     padding: 22px 20px 0px 20px;
     background: #F9F7F6;


### PR DESCRIPTION
This change fixes an issue when viewing the homepage on an Apple Mac where the alignment is not correct at a certain screen width. The issue only appears when there are 3 image blocks instead of 2.

Fixes [AB#73553](https://dev.azure.com/hedev/Inventory/_sprints/taskboard/Inventory/Inventory/Inventory/Sprint%2096?workitem=73553)