### PR TITLE
Add find button to GLHER homepage #AB74626

### DIFF
--- a/arches_her/media/css/branding.css
+++ b/arches_her/media/css/branding.css
@@ -360,6 +360,11 @@
         top: -38px;
         left: 0;
     }
+    .searchbtn-container {
+        display: flex;
+        justify-content: center;
+        padding-bottom: 15px;
+    }
 
 }
 
@@ -381,9 +386,9 @@
 }
 
 .landing-page .btn-primary {
-    height: 51px;
     font-weight: 300;
     line-height: 1.5;
+    white-space: normal;
 }
 
 .landing-page .navbar-nav>li>a {
@@ -600,7 +605,10 @@
 }
 
 .row.featurette2 {
-    margin: 50px auto 0 auto;
+    margin: 20px auto 0 auto;
+}
+
+.row.featurette2 .featurette2-sub-container {
     border-top: 1px solid #707070;
     border-bottom: 1px solid #707070;
 }
@@ -848,7 +856,7 @@
     }
 
     .row.featurette2 {
-        margin-top: 243px;
+        margin-top: 253px;
     }
 
     .featurette3-row {
@@ -1177,7 +1185,7 @@
     }
 
     .row.featurette2 {
-        margin: 235px auto 0 auto;
+        margin: 260px auto 0 auto;
     }
 
     .featurette3-row, .featurette4-row, .featurette6-row {

--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -144,13 +144,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 </div>
             </div>
             <div class="row featurette2">
-                <h2>On this page</h2>
-                <ol>
-                    <li><a href="#bm-about">About</a></li>
-                    <li><a href="#bm-how-to-use">How to use</a></li>
-                    <li><a href="#bm-volunteering">Volunteering with GLHER</a></li>
-                    <li><a href="#bm-themes">Heritage Themes</a></li>
-                </ol>
+                <div class="searchbtn-container">
+                    <p>
+                        <a class="btn btn-primary btn-lg" href="{% url 'search_home' %}" role="button">Search the Greater London Historic Environment Record</a>
+                    </p>
+                </div>
+                <div class="featurette2-sub-container">
+                    <h2>On this page</h2>
+                    <ol>
+                        <li><a href="#bm-about">About</a></li>
+                        <li><a href="#bm-how-to-use">How to use</a></li>
+                        <li><a href="#bm-volunteering">Volunteering with GLHER</a></li>
+                        <li><a href="#bm-themes">Heritage Themes</a></li>
+                    </ol>
+                </div>
             </div>
             <div class="row featurette3">
                 <h2 id="bm-about">About</h2>


### PR DESCRIPTION
This changes adds a "Search the Greater London Historic Environment Record" button, as agreed in [74626](https://dev.azure.com/hedev/Inventory/_workitems/edit/74626) . Clicking the button takes you to the search page. The change has been checked at various screen dimensions including mobile view using BrowserStack for responsiveness etc. Accessibility tests have been passed by Imogen.

![image](https://github.com/user-attachments/assets/74557ec7-7b42-401a-a9e5-196797ad42e0)
