### PR TITLE
NonStrictManifestStaticFilesStorage add wider exception handling

### DIFF
--- a/arches_her/storage.py
+++ b/arches_her/storage.py
@@ -16,25 +16,32 @@ class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
         """
         Override hashed_name to avoid raising errors when a file is missing.
         """
+        method_name = inspect.currentframe().f_code.co_name
+
         try:
             # Call the original hashed_name method
             return super().hashed_name(name, content, filename)
 
         except ValueError as e:
             # Log a warning for the missing file and return the original name (no hashing)
-            method_name = inspect.currentframe().f_code.co_name
             logger.warning(f"{self.class_name}.{method_name} - File not found, skipping hash for {name}: {e}")
             return name  # Return the un-hashed name
+        except Exception as e:
+            logger.error(f"{self.class_name}.{method_name} - Unexpected error hashing {name}: {e}", exc_info=True)
+            return name  # Return the un-hashed name to avoid disruption
 
     def post_process(self, paths, dry_run=False, **options):
         """
         Override post_process to handle missing files gracefully.
         """
+        method_name = inspect.currentframe().f_code.co_name
+
         try:
             results = super().post_process(paths, dry_run, **options)
             for result in results:
                 yield result
         except ValueError as e:
-            method_name = inspect.currentframe().f_code.co_name
             logger.warning(f"{self.class_name}.{method_name} - Skipping missing file during post-processing: {e}")
             # Continue processing despite missing files
+        except Exception as e:
+            logger.error(f"{self.class_name}.{method_name} - Unexpected error during post-processing: {e}", exc_info=True)

--- a/arches_her/storage.py
+++ b/arches_her/storage.py
@@ -2,13 +2,12 @@ from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 import logging
 import inspect
 
-logger = logging.getLogger(__name__)
-
 
 class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
     manifest_strict = False
 
     def __init__(self, *args, **kwargs):
+        self.logger = logging.getLogger(__name__)
         super().__init__(*args, **kwargs)
         self.class_name = self.__class__.__name__
 
@@ -24,10 +23,10 @@ class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
 
         except ValueError as e:
             # Log a warning for the missing file and return the original name (no hashing)
-            logger.warning(f"{self.class_name}.{method_name} - File not found, skipping hash for {name}: {e}")
+            self.logger.warning(f"{self.class_name}.{method_name} - File not found, skipping hash for {name}: {e}")
             return name  # Return the un-hashed name
         except Exception as e:
-            logger.error(f"{self.class_name}.{method_name} - Unexpected error hashing {name}: {e}", exc_info=True)
+            self.logger.error(f"{self.class_name}.{method_name} - Unexpected error hashing {name}: {e}", exc_info=True)
             return name  # Return the un-hashed name to avoid disruption
 
     def post_process(self, paths, dry_run=False, **options):
@@ -41,7 +40,7 @@ class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
             for result in results:
                 yield result
         except ValueError as e:
-            logger.warning(f"{self.class_name}.{method_name} - Skipping missing file during post-processing: {e}")
+            self.logger.warning(f"{self.class_name}.{method_name} - Skipping missing file during post-processing: {e}")
             # Continue processing despite missing files
         except Exception as e:
-            logger.error(f"{self.class_name}.{method_name} - Unexpected error during post-processing: {e}", exc_info=True)
+            self.logger.error(f"{self.class_name}.{method_name} - Unexpected error during post-processing: {e}", exc_info=True)

--- a/arches_her/templates/views/components/plugins/active-consultations.htm
+++ b/arches_her/templates/views/components/plugins/active-consultations.htm
@@ -136,7 +136,7 @@
                 <!-- Splash Title -->
                     <!-- ko ifnot: searched -->
                     <div class="img-lg img-circle rr-splash-img-container">
-                        <img class="rr-splash-img" src="{% static "/img/inspection.png" %}" alt="Active Consultations">
+                        <img class="rr-splash-img" src="{% static "img/inspection.png" %}" alt="Active Consultations">
                     </div>
                     <div class="rr-splash-title">{% trans "Welcome to Arches' Active Consultations" %}</div>
                     <div class="rr-splash-description">{% trans "There are currently no Active Consultations." %}</div>


### PR DESCRIPTION
Was only handling ValueError exceptions. Now falling back to capture Exception. Root issue was found during Active Consultations page loading. inspection.png resource was referenced as `src="{% static "/img/inspection.png" %}"` instead of `src="{% static "img/inspection.png" %}"` - note the initial slash.

Also fixed the relative path for `inspection.png`.