### PR TITLE
Add authenticate management command AB#78894

### DIFF
--- a/arches_her/management/commands/hapi.py
+++ b/arches_her/management/commands/hapi.py
@@ -52,6 +52,7 @@ from dateutil.relativedelta import relativedelta
 import re
 from colorama import Fore, init
 from ...services import validate as validate_service
+from ...services import authenticate as authenticate_service
 
 logger = logging.getLogger(__name__)
 init(autoreset=True)
@@ -207,7 +208,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "operation",
             nargs="?",
-            choices=["upload", "validate", "generate"],
+            choices=["upload", "validate", "generate", "authenticate"],
         )
         parser.add_argument(
             "-u", "--uuid",
@@ -265,6 +266,20 @@ class Command(BaseCommand):
             default=None,
             help="Batch ID",
         )
+        parser.add_argument(
+            "-user", "--username",
+            action="store",
+            dest="username",
+            default=None,
+            help="Username for HAPI authentication",
+        )
+        parser.add_argument(
+            "-pass", "--password",
+            action="store",
+            dest="password",
+            default=None,
+            help="Password for HAPI authentication",
+        )
 
     def handle(self, *args, **options):
         operation = options["operation"]
@@ -292,6 +307,11 @@ class Command(BaseCommand):
                 internal_call=internal_call,
                 batch_id=options["batch_id"]
             )
+        elif operation == "authenticate":
+            self.authenticate(
+                username=options["username"],
+                password=options["password"]
+            )
 
     def validate(self, resource_uuid=None, input: str = None, output: str = None, internal_call: bool = False, batch_id: str = None) -> str:
         if (resource_uuid and input) or (not resource_uuid and not input):
@@ -309,7 +329,7 @@ class Command(BaseCommand):
             validate_filename(input)
             uuid_list = validate_uuids(input)
 
-        data = validate_service(self, uuid_list)
+        data = validate_service(uuid_list)
 
         if internal_call:
             self.stdout.write(data)
@@ -385,3 +405,7 @@ class Command(BaseCommand):
                 file.write(data)
         else:
             print(data)
+
+    def authenticate(self, username: str, password: str) -> Optional[str]:
+        bearer = authenticate_service(username, password)
+        print(bearer) if bearer else None

--- a/arches_her/services.py
+++ b/arches_her/services.py
@@ -39,13 +39,15 @@ def generate(resource_uuid) -> dict:
     resource_data = json.loads(resource_data)
     return {"data": resource_data}
 
-def authenticate(self, username: str, password: str) -> Optional[str]:
+def authenticate(username: str, password: str) -> Optional[str]:
     url = settings.HAPI_AUTHENTICATE_URL
     try:
         response = requests.post(url, json={"username": username, "password": password})
+        if response.status_code != 200:
+            response.raise_for_status()
     except requests.RequestException as e:
-        print(f"HTTP request failed: {e}")
-        return None
+        logger.error(f"HTTP request failed: {e}")
+    
     token = None
     if response.status_code == 200:
         token = response.json()["token"]


### PR DESCRIPTION
[AB#78894](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/78894)

Wired up `authenticate` management command:

```shell
python manage.py hapi authenticate -user "{user name}" -pass "{password}"
python manage.py hapi authenticate --username "{user name}" --password "{password}"
```

Returns the bearer token if successful e.g. 

```shell
root@63ad4e51654b:/web_root/arches_her# python manage.py hapi authenticate -user "obfuscated username" -pass "obfuscated password"
System check identified some issues:

WARNINGS:
?: (urls.W005) URL namespace 'admin' isn't unique. You may not be able to reverse all URLs in this namespace
?: (urls.W005) URL namespace 'oauth2' isn't unique. You may not be able to reverse all URLs in this namespace
292|CmcFqK8BnSbqJpuPi4hADosT7S8aCkIUEokDbk0O896d4a10
```