### PR TITLE
"Batch Create" management command AB#78898

### DIFF
--- a/arches_her/management/commands/hapi.py
+++ b/arches_her/management/commands/hapi.py
@@ -301,11 +301,13 @@ class Command(BaseCommand):
         internal_call = options["internal_call"]
         internal_call = (internal_call.lower() == "true") if internal_call else False
         counts_str = options["counts"]
-        try:
-            counts = json.loads(counts_str)
-        except Exception as e:
-            print(f"Error parsing counts: {e}")
-            return
+        counts = {}
+        if counts_str:
+            try:
+                counts = json.loads(counts_str)
+            except Exception as e:
+                print(f"Error parsing counts: {e}")
+                return
 
         if operation == "validate":
             self.validate(

--- a/arches_her/management/commands/hapi.py
+++ b/arches_her/management/commands/hapi.py
@@ -40,7 +40,7 @@ from ...data_access.monument import (
     get_monument_sources
 )
 from ...models.factory import create_resource
-from typing import List, Optional
+from typing import Dict, List, Optional
 import logging
 import uuid
 import os
@@ -53,6 +53,7 @@ import re
 from colorama import Fore, init
 from ...services import validate as validate_service
 from ...services import authenticate as authenticate_service
+from ...services import batch_create as batch_create_service
 
 logger = logging.getLogger(__name__)
 init(autoreset=True)
@@ -208,7 +209,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "operation",
             nargs="?",
-            choices=["upload", "validate", "generate", "authenticate"],
+            choices=["upload", "validate", "generate", "authenticate", "batch_create"],
         )
         parser.add_argument(
             "-u", "--uuid",
@@ -280,11 +281,32 @@ class Command(BaseCommand):
             default=None,
             help="Password for HAPI authentication",
         )
+        parser.add_argument(
+            "-bt", "--bearer_token",
+            action="store",
+            dest="bearer_token",
+            default=None,
+            help="Bearer token for HAPI batch creation",
+        )
+        parser.add_argument(
+            "-c", "--count",
+            action="store",
+            dest="counts",
+            default=None,
+            help='JSON object for counts e.g. {"total_count": 20, "published_count": 18, "submitted_count": 2}',
+        )
 
     def handle(self, *args, **options):
         operation = options["operation"]
         internal_call = options["internal_call"]
         internal_call = (internal_call.lower() == "true") if internal_call else False
+        counts_str = options["counts"]
+        try:
+            counts = json.loads(counts_str)
+        except Exception as e:
+            print(f"Error parsing counts: {e}")
+            return
+
         if operation == "validate":
             self.validate(
                 resource_uuid=options["resource_uuid"],
@@ -309,6 +331,13 @@ class Command(BaseCommand):
             )
         elif operation == "authenticate":
             self.authenticate(
+                username=options["username"],
+                password=options["password"]
+            )
+        elif operation == "batch_create":
+            self.batch_create(
+                counts = counts,
+                bearer_token=options["bearer_token"],
                 username=options["username"],
                 password=options["password"]
             )
@@ -409,3 +438,14 @@ class Command(BaseCommand):
     def authenticate(self, username: str, password: str) -> Optional[str]:
         bearer = authenticate_service(username, password)
         print(bearer) if bearer else None
+
+    def batch_create(self, counts: Dict, bearer_token: str = None, username: str = None, password: str = None) -> Optional[int]:
+        required_count_keys = {"total_count", "published_count", "submitted_count"}
+        if not required_count_keys.issubset(counts.keys()):
+            # fmt: off
+            print(
+                f"{Fore.RED}Counts must contain the following keys: {Fore.GREEN}{', '.join(required_count_keys)}{Fore.RESET}"
+            )
+            return
+        batch_number = batch_create_service(counts, bearer_token, username, password)
+        print(batch_number) if batch_number else None

--- a/arches_her/services.py
+++ b/arches_her/services.py
@@ -1,5 +1,5 @@
 from arches.app.models.system_settings import settings
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 import requests
 from django.core.management import call_command
 import json
@@ -53,15 +53,20 @@ def authenticate(username: str, password: str) -> Optional[str]:
         token = response.json()["token"]
     return token
 
-def batch_create(self, resources: list) -> Optional[str]:
+def batch_create(counts: Dict, bearer_token: str = None, username: str = None, password: str = None) -> Optional[int]:
     url = settings.HAPI_BATCH_CREATE_URL
+    if not bearer_token:
+        bearer_token = authenticate(username, password)
+    if not bearer_token:
+        return None
     try:
-        # TODO Need to send the authentication token in the Authorization
-        response = requests.post(url, json={"resources": resources})
+        # TODO Need to send the bearer token in the Authorization
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        response = requests.post(url, json=counts, headers=headers)
         response.raise_for_status()
         return response.json()["batch_id"]
     except requests.RequestException as e:
-        print(f"H.API batch creation failed: {e}")
+        logger.error(f"H.API batch creation failed: {e}")
         return None
 
 def batch_submit(self, batch_id: str) -> bool:


### PR DESCRIPTION
[AB#78898](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/78898)

Management command that will use the bearer token, if one is supplied; alternatively the username and password. Need to specify the counts too. If all is well, a batch number will be returned.

```shell
> python manage.py hapi authenticate --user "rob.oates" --password "P@55w0rd!"
> 302|Jb7xhA9fTsYRjdEefkCwurPhs0zClyO9pfmj37MD9236eec5

python manage.py hapi batch_create --bearer_token "302|Jb7xhA9fTsYRjdEefkCwurPhs0zClyO9pfmj37MD9236eec5"
    --count '{"total_count": 20, "published_count": 18, "submitted_count": 4}'
> 281
```
or...

```
> python manage.py hapi batch_create --user "rob.oates" --password "P@55w0rd!" 
    --count '{"total_count": 20, "published_count": 18, "submitted_count": 4}'
> 282
```