### PR TITLE
Add authenticate and batch create endpoints

### DIFF
--- a/arches_her/urls.py
+++ b/arches_her/urls.py
@@ -10,7 +10,12 @@ from arches_her.views.active_consultations import ActiveConsultationsView
 from arches.app.views import main
 from arches.app.views.user import UserManagerView
 from arches.app.views.auth import PasswordResetView
-from .views.hapi import ValidateResourceView, GenerateResourceView
+from .views.hapi import (
+    ValidateResourceView, 
+    GenerateResourceView, 
+    AuthenticateView, 
+    BatchCreateView
+)
 
 uuid_regex = settings.UUID_REGEX
 
@@ -42,5 +47,7 @@ urlpatterns = [
     url(r'^hapi/validate/(?P<resource_uuid>%s)$' % uuid_regex, ValidateResourceView.as_view(), name="validate_resource"),
     url(r'^hapi/validate$', ValidateResourceView.as_view(), name="validate_resource"),
     url(r'^hapi/generate/(?P<resource_uuid>%s)$' % uuid_regex, GenerateResourceView.as_view(), name="generate_resource"),
-    url(r'^hapi/generate$', GenerateResourceView.as_view(), name="generate_resource_no_uuid"),
+    url(r'^hapi/generate$', GenerateResourceView.as_view(), name="generate_resource"),
+    url(r'^hapi/authenticate$', AuthenticateView.as_view(), name="authenticate"),
+    url(r'^hapi/batch/create$', BatchCreateView.as_view(), name="batch_create"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/arches_her/views/hapi.py
+++ b/arches_her/views/hapi.py
@@ -4,7 +4,9 @@ from django.views import View
 from django.utils.decorators import method_decorator
 from ..services import (
     validate as validate_service,
-    generate as generate_service
+    generate as generate_service,
+    authenticate as authenticate_service,
+    batch_create as batch_create_service,
 )
 
 
@@ -57,3 +59,47 @@ class GenerateResourceView(View):
 
         result = generate_service(resource_uuid)
         return JsonResponse(result)
+
+
+@method_decorator(superuser_required, name='dispatch')
+class AuthenticateView(View):
+    def get(self, request):
+        try:
+            body = json.loads(request.body)
+            username = body.get("username")
+            password = body.get("password")
+        except:
+            return HttpResponse(status=401)
+
+        token = authenticate_service(username, password)
+        if not token:
+            return HttpResponse(status=401)
+        return HttpResponse(token, status=200)
+
+
+@method_decorator(superuser_required, name='dispatch')
+class BatchCreateView(View):
+    def get(self, request):
+        try:
+            body = json.loads(request.body)
+            token = body.get("token")
+            username = body.get("username")
+            password = body.get("password")
+            counts = {
+                "total_count": body.get("total_count", 0),
+                "published_count": body.get("published_count", 0),
+                "submitted_count": body.get("submitted_count", 0),
+            }
+        except:
+            return HttpResponse(status=401)
+
+        batch_number = batch_create_service(bearer_token=token, username=username, password=password,
+                                            counts=counts)
+        if not batch_number:
+            return HttpResponse(status=401)
+        return HttpResponse(batch_number, status=200)
+
+
+@method_decorator(superuser_required, name='dispatch')
+class BatchSubmitView(View):
+    pass


### PR DESCRIPTION
Can perform the following (when signed in to Arches as admin user):
- `/hapi/authenticate`
- `/hapi/batch/create`

### Authenticate
Returns the bearer token. Pass in to the body: `username` and `password`

### Batch Create
Returns batch number. Pass in to the body: `token` or `username` and `password`; `total_count`, `published_count` and `submitted_count`