### PR TITLE
AB#82184 Add labels to password reset fields

### DIFF
--- a/arches_her/templates/registration/password_reset_confirm.html
+++ b/arches_her/templates/registration/password_reset_confirm.html
@@ -14,10 +14,12 @@
 			</div>
 			<div class="form-group">
 				{{ form.new_password1.errors }}
+				<label class="reqlabel control-label widget-input-label" for="id_new_password1">{% trans "New password" %}</label>
 				{{ form.new_password1 }}
 			</div>
 			<div class="form-group">
 				{{ form.new_password2.errors }}
+				<label class="reqlabel control-label widget-input-label" for="id_new_password2">{% trans "Re-enter new password" %}</label>
 				{{ form.new_password2 }}
 			</div>
 			<div class="form-group">


### PR DESCRIPTION
This fix adds correct form labels to the password reset fields