### PR TITLE
Homepage banner notification AB#77470

### DIFF
--- a/arches_her/media/css/branding.css
+++ b/arches_her/media/css/branding.css
@@ -702,6 +702,43 @@
 
 /* Featurettes - End */
 
+/* Notification Banner Styles - Start*/
+
+.notification-banner {
+    background: #d1691e;
+    color: white;
+    border-radius: 10px;
+    text-align: center;
+    padding: 16px 24px;
+    font-size: 1.6em;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    align-items: center;
+    justify-content: center;
+    margin: 0 0 20px 0;
+    width: 100%;
+    max-width: 1090px;
+    box-sizing: border-box;
+}
+
+@media (max-width: 767px) {
+    .notification-banner {
+        border-radius: 0;
+        font-size: 1.2em;
+    }
+    .notification-banner + .featurette1-left-container {
+        margin-top: 56px;
+    }
+}
+
+@media (max-width: 767px) {
+    .featurette1-left-container--with-notification {
+    top: calc(62vw + 80px) !important;
+    }
+
+}
+
+/* Notification Banner Styles - End */
+
 /* Footer - Start */
 
 .landing-page footer {

--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -142,7 +142,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 <div class="featurette1-right-container pull-right">
                     {% if notification %}
                     <div class="notification-banner">
-                        {{ notification|safe}}
+                        {{ notification|safe }}
                     </div>
                     {% endif %}
                     <img src="{% static 'img/landing/featurette1.png' %}" alt="Photo of the London landscape" class="img-rounded img-responsive">

--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -141,7 +141,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 </div>
                 <div class="featurette1-right-container pull-right">
                     {% if notification %}
-                    <div class="notification-banner">
+                    <div class="notification-banner" aria-live="assertive">
                         {{ notification|safe }}
                     </div>
                     {% endif %}

--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -134,12 +134,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         </p>
         <div class="container">
             <div class="row featurette1">
-                <div class="featurette1-left-container">
+                <div class="featurette1-left-container{% if notification %} featurette1-left-container--with-notification{% endif %}">
                     <h1>Greater London Historic Environment Record<br/>
                         (GLHER)</h1>
                     <p class="lead">The online heritage information and management system for London.</p>
                 </div>
                 <div class="featurette1-right-container pull-right">
+                    {% if notification %}
+                    <div class="notification-banner">
+                        {{ notification|safe}}
+                    </div>
+                    {% endif %}
                     <img src="{% static 'img/landing/featurette1.png' %}" alt="Photo of the London landscape" class="img-rounded img-responsive">
                 </div>
             </div>

--- a/arches_her/views/index.py
+++ b/arches_her/views/index.py
@@ -50,5 +50,6 @@ class IndexView(TemplateView):
                     context["plugins"].append(plugin)
 
         context["user_is_reviewer"] = request.user.groups.filter(name="Resource Reviewer").exists()
+        context["notification"] = getattr(settings, "NOTIFICATION", None)
 
         return render(request, "index.htm", context)

--- a/arches_her/views/index.py
+++ b/arches_her/views/index.py
@@ -50,6 +50,6 @@ class IndexView(TemplateView):
                     context["plugins"].append(plugin)
 
         context["user_is_reviewer"] = request.user.groups.filter(name="Resource Reviewer").exists()
-        context["notification"] = getattr(settings, "NOTIFICATION", None)
+        context["notification"] = getattr(settings, "MAINTENANCE_NOTIFICATION", None)
 
         return render(request, "index.htm", context)


### PR DESCRIPTION
[AB#77470](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/77470)

Adds a notification banner to the homepage. Banner only appears when library variable `maintenance-notification` is populated. Basic HTML formatting is possible. To use `<em>` tag, replace the angle brackets with handlebars, i.e.  `{{em}}`. This is due to angle brackets not being allowed in variable values, and will actively break the build pipeline.

The example below uses: `{{b}}There will be maintenance taking place on Monday 17th December between 4pm and 8pm.{{/b}}{{br}}At this time, there will be no access to the system.`.

<img width="1606" height="794" alt="image" src="https://github.com/user-attachments/assets/8ae2320c-8989-4f4a-bdbb-294c745a761f" />
